### PR TITLE
Review from Dave Cridland

### DIFF
--- a/draft-ietf-mls-architecture.md
+++ b/draft-ietf-mls-architecture.md
@@ -106,7 +106,7 @@ Messaging Layer Security (MLS) specifies an architecture (this document)
 and an abstract protocol {{MLSPROTO}} for providing end-to-end security
 in this setting. MLS is not intended as a full instant messaging
 protocol but rather is intended to be embedded in a concrete protocol
-such as XMPP {{?RFC3920}}. In addition, it does not specify a complete
+such as XMPP {{?RFC6120}}. In addition, it does not specify a complete
 wire encoding, but rather a set of abstract data structures which
 can then be mapped onto a variety of concrete encodings, such as
 TLS {{?I-D.ietf-tls-tls13}}, CBOR {{?RFC7049}}, and JSON {{?RFC7159}}.
@@ -560,7 +560,7 @@ In general we do not consider Denial of Service (DoS) resistance to be the respo
 of the protocol. However, it should not be possible for anyone to perform a
 trivial Denial of Service (DoS) attack from which it is hard to recover.
 
-#### Deniability
+#### Non-Repudiation and Deniability
 
 As described in {{client-compromise}}, MLS aims to provide data origin authentication
 within a group, such that one group member cannot send a message that appears


### PR DESCRIPTION
* Change reference to XMPP to the current RFC.
* Change heading of "Deniability" section, which also discusses non-repudiation, to "Non-Repudiation and Deniability".

I wondered if that latter section should note that a third-party (ie, non-Member) cannot identify a sender from a given encrypted message, but then I wondered if that was the case or not.