### PR TITLE
Fix broken links to point directly to Github

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 This is the working area for the IETF MLS Working Group Internet-Draft, "The Messaging Layer Security (MLS) Architecture".
 
-* [Editor's Copy](https://mlswg.github.io/mls-architecture/#go.draft-ietf-mls-architecture.html)
+* [Editor's Copy](https://github.com/mlswg/mls-architecture/blob/master/draft-ietf-mls-architecture.md)
 * [Working Group Draft](https://tools.ietf.org/html/draft-ietf-mls-architecture)
-* [Compare Editor's Copy to Working Group Draft](https://mlswg.github.io/mls-architecture/#go.draft-ietf-mls-architecture.diff)
+* [Compare Editor's Copy to Working Group Draft](https://github.com/mlswg/mls-architecture/compare/draft-ietf-mls-architecture-00...master)
 
 ## Building the Draft
 


### PR DESCRIPTION
Previously they pointed to mlswg.github.io/... but that doesn't work now that we use it for an actual homepage