### PR TITLE
removing 2119 language

### DIFF
--- a/draft-ietf-mls-architecture.md
+++ b/draft-ietf-mls-architecture.md
@@ -44,8 +44,6 @@ author:
     email: alan@wire.com
 
 informative:
-  RFC2119:
-
   MLSPROTO:
        title: "Messaging Layer Security Protocol"
        date: 2018
@@ -292,8 +290,8 @@ the functional and security guarantees provided by MLS may differ.
 Upon joining the system, each Client stores its initial cryptographic
 key material with the DS. This key material represents the initial contribution
 from each member that will be used in the establishment of the shared group
-key. This initial keying material MUST be authenticated using
-the Client's identity key. Thus, the Client stores:
+key. This initial keying material is authenticated using
+the Client's identity key. Thus, then Client stores:
 
 * A credential from the Authentication service attesting to the
   binding between the Member and the Client's identity key.

--- a/draft-ietf-mls-architecture.md
+++ b/draft-ietf-mls-architecture.md
@@ -291,7 +291,7 @@ Upon joining the system, each Client stores its initial cryptographic
 key material with the DS. This key material represents the initial contribution
 from each member that will be used in the establishment of the shared group
 key. This initial keying material is authenticated using
-the Client's identity key. Thus, then Client stores:
+the Client's identity key. Thus, the Client stores:
 
 * A credential from the Authentication service attesting to the
   binding between the Member and the Client's identity key.


### PR DESCRIPTION
Removing 2119 "MUST" as agreed in Paris.  Note that this is the minimal change and in another PR I will suggest removing as many lower case instances of must, should, etc. as possible.