### PR TITLE
Align language and syntax with protocol document

### DIFF
--- a/draft-ietf-mls-architecture.md
+++ b/draft-ietf-mls-architecture.md
@@ -233,13 +233,15 @@ devices to interact with the Messaging Service.
 These members will typically correspond to end-user devices such as phones,
 web clients or other devices running MLS, which are called clients.
 
-Each client owns a long term identity key pair that uniquely defines
-its identity to other clients or members a the Group.
+Each client owns at least one long term identity key pair that
+uniquely defines its identity to other clients or members a the Group.
 Because a single user may operate multiple devices simultaneously
 (e.g., a desktop and a phone) or sequentially (e.g., replacing
 one phone with another), the formal definition of a group in MLS
 is the set of clients that has knowledge of the shared group secret
 established in the group key establishment phase of the protocol.
+Multiple user devices can be grouped, appearing as one virtual
+client to the rest of the group.
 
 In some messaging systems, clients belonging to the same user must
 all share the same identity key pair, but MLS does not assume this.

--- a/draft-ietf-mls-architecture.md
+++ b/draft-ietf-mls-architecture.md
@@ -126,15 +126,15 @@ requirements which it is intended to fulfill.
 # General Setting
 
 A Group using a Messaging Service (MS) comprises a set of participants
-called Members where each Member is typically expected to own multiple
+called Members where each member is typically expected to own multiple
 devices, called Clients.  A group may be as small as two members
 (the simple case of person to person messaging) or as large as
-thousands. In order to communicate securely, Group
-Members initially use services at their disposal to obtain the
-necessary secrets and credentials required for security.
+thousands. In order to communicate securely, clients initially
+use services at their disposal to obtain the necessary secrets
+and credentials required for security.
 
 The Messaging Service (MS) presents as two abstract services that allow
-Members to prepare for sending and receiving messages securely:
+clients to prepare for sending and receiving messages securely:
 
 - An Authentication Service (AS) which is responsible for maintaining
   user long term identities, issuing credentials which allow them to
@@ -147,8 +147,8 @@ Members to prepare for sending and receiving messages securely:
   be responsible for acting as a "broadcaster" where the sender sends
   a single message to a group which is then forwarded to each
   recipient in the group by the DS. The DS is also responsible for storing and
-  delivering initial public key material required in order to proceed
-  with the group secret key establishment process.
+  delivering initial public key material required by clients in order
+  to proceed with the group secret key establishment process.
 
 ~~~~
       ----------------      --------------
@@ -162,8 +162,8 @@ Members to prepare for sending and receiving messages securely:
      *      ----------       ----------       ----------     *
      *     | Client 0 |     | Client 1 |     | Client N |    *
      *      ----------       ----------       ----------     *
-     *      ............................      ...........    *
-     *      Member 0                          Member 1       *
+     *     .............................     ............    *
+     *     User 0                            User 1          *
      *                                                       *
      *********************************************************
 
@@ -199,9 +199,9 @@ A typical group messaging scenario might look like this:
 
 Clients may wish to do the following:
 
- -  create a group by inviting a set of other members;
+ -  create a group by inviting a set of other clients;
 
- -  add one or more members to an existing group;
+ -  add one or more clients to an existing group;
 
  -  remove one or more members from an existing group;
 
@@ -213,52 +213,52 @@ Clients may wish to do the following:
 
  -  receive a message from someone in the group.
 
-At the cryptographic level, Clients in groups (and by extension Members)
-are peers. For instance, any Client can add a member to a group. This
+At the cryptographic level, clients in groups (and by extension Members)
+are peers. For instance, any client can add another client to a group. This
 is in contrast to some designs in which there is a single group
 controller who can modify the group. MLS is compatible with having
 group administration restricted to certain users, but we assume that
-those restrictions are enforced by authentication and access control.
+those restrictions are enforced by authentication and access control
+at the application layer.
 Thus, for instance, while it might be technically possible for any
-member to send a message adding a new member to a group, the group
+member to send a message adding a new client to a group, the group
 might have the policy that only certain members are allowed to make
 changes and thus other members can ignore or reject such a message
 from an unauthorized user.
 
 ## Group, Members and Clients
 
-In MLS a Group is defined as a set of Members who possibly use multiple
-endpoint devices (Clients) to interact with the Messaging Service.
-These Clients will typically correspond to end-user devices such as phones,
-web clients or other devices running MLS.
+Informally, a group is a set of users who possibly use multiple endpoint
+devices to interact with the Messaging Service.
+These members will typically correspond to end-user devices such as phones,
+web clients or other devices running MLS, which are called clients.
 
-Each member device owns a long term identity key pair that uniquely defines
-its identity to other Members of the Group.
-Because a single Member may operate multiple devices simultaneously
+Each client owns a long term identity key pair that uniquely defines
+its identity to other clients or members a the Group.
+Because a single user may operate multiple devices simultaneously
 (e.g., a desktop and a phone) or sequentially (e.g., replacing
-one phone with another), the formal definition of a Group in MLS
-is the set of Clients that has legitimate knowledge of the shared (Encryption)
-Group Key established in the group key establishment phase of the protocol.
+one phone with another), the formal definition of a group in MLS
+is the set of clients that has knowledge of the shared group secret
+established in the group key establishment phase of the protocol.
 
-In some messaging systems, Clients belonging to the same Member must
+In some messaging systems, clients belonging to the same user must
 all share the same identity key pair, but MLS does not assume this.
 The MLS architecture considers the more general case and allows for
-important use cases, such as a Member adding a new Client when all their
-existing clients are offline.
+important use cases, such as a member adding a new client when all
+their existing clients are offline.
 
-MLS has been designed to provide similar security guarantees to all Clients,
-for all group sizes, even when it reduces to only two Clients.
+MLS has been designed to provide similar security guarantees to all
+clients, for all group sizes, even when it reduces to only two clients.
 
 ## Authentication Service
 
-The basic function of the Authentication Service is to provide a
+The basic function of the Authentication Service (AS) is to provide a
 trusted mapping from user identities (usernames, phone numbers, etc.),
-which exist 1:1 with Members, to identity keys, which may either
-be one per Client or may be shared amongst the Clients attached
-to a Member.
+to long-term identity keys, which may either be one per client or may be
+shared amongst the clients attached to a user. It typically acts as:
 
-* A certification authority or similar service which signs some sort of
-  portable credential binding an identity to a key.
+* A certification authority, or similar service, which signs some sort of
+  portable credential binding an identity to a key;
 
 * A directory server which provides the key for a given identity
   (presumably this connection is secured via some form of transport
@@ -277,46 +277,44 @@ necessarily be somewhat vulnerable to attack by a malicious or untrusted AS.
 The Delivery Service (DS) is expected to play multiple roles in the
 Messaging Service architecture:
 
-* To act as a directory service providing the keying material
-  (authentication keys and initial keying material) for Clients to use.
-  This allows a Client to establish a shared key
-  and send encrypted messages to other Clients even if the
-  other Client is offline.
+* To act as a directory service providing the initial keying material
+  for clients to use.
+  This allows a client to establish a shared key and send encrypted
+  messages to other clients even if the other client is offline.
 
-* To route messages between Clients and to act as a message
-  broadcaster, taking in one message and forwarding it to multiple Clients
-  (also known as "server side fanout").
+* To route messages between clients and to act as a message
+  broadcaster, taking in one message and forwarding it to multiple
+  clients (also known as "server side fanout").
 
 
-Depending on the level of trust given by the Group to the Delivery Service,
+Depending on the level of trust given by the group to the Delivery Service,
 the functional and security guarantees provided by MLS may differ.
 
 ### Key Storage
 
-Upon joining the system, each Client stores its initial cryptographic
+Upon joining the system, each client stores its initial cryptographic
 key material with the DS. This key material represents the initial contribution
-from each member that will be used in the establishment of the shared group
-key. This initial keying material is authenticated using
-the Client's identity key. Thus, the Client stores:
+that will be used in the establishment of the shared group secret.
+This initial keying material is authenticated using the client's
+identity key. Thus, the client stores:
 
 * A credential from the Authentication service attesting to the
-  binding between the Member and the Client's identity key.
+  binding between the user and the client's identity key.
 
-* The member's initial keying material signed with the Client's
+* The client's initial keying material signed with the client's
   identity key.
 
-As noted above, Members may have multiple Clients, each with their
-own keying material, and thus there may be multiple entries stored
-by each Member.
+As noted above, users may own multiple clients, each with their
+own keying material, and thus there may be multiple entries
+stored by each user.
 
 ### Key Retrieval
 
-When a Client wishes to establish a group and send an initial message
+When a client wishes to establish a group and send an initial message
 to that group, it contacts the DS and retrieves the initial key
-material for each other Member, verifies it using the identity key,
-and then is able to form a joint key with each other Client, and
-from those forms the group key, which it can use for the encryption of
-messages.
+material for each other client, verifies it using the identity key,
+and from those forms the group secret, which it can use for the
+encryption of messages.
 
 ### Delivery of messages and attachments {#delivery-guarantees}
 
@@ -324,17 +322,22 @@ The DS's main responsibility is to ensure delivery of messages.
 Specifically, we assume that DSs provide:
 
 * Reliable delivery: when a message is provided to the DS,
-  it is eventually delivered to all group members.
+  it is eventually delivered to all clients.
 
 * In-order delivery: messages are delivered to the group
-  in the order they are received from a given Client
+  in the order they are received from a given client
   and in approximately the order in which they are sent
-  by Clients. The latter is an approximate guarantee because
-  multiple Clients may send messages at the same time
-  and so the DS needs some latitude in reordering between Clients.
+  by clients. The latter is an approximate guarantee because
+  multiple clients may send messages at the same time
+  and so the DS needs some latitude in enforcing ordering
+  across clients.
 
-* Consistent ordering: the DS must ensure that all Clients
-  have the same view of message ordering.
+* Consistent ordering: the DS must ensure that all clients
+  have the same view of message ordering for cryptographically
+  relevant operations. This means that the DS MUST enforce
+  global consistency of the ordering of these messages while
+  MLS provides causal consistency of the application messages
+  for each sender.
 
 Note that the DS may provide ordering guarantees by ensuring
 in-order delivery or by providing messages with some kind
@@ -342,44 +345,41 @@ of sequence information and allowing clients to reorder on
 receipt.
 
 The MLS protocol itself can verify these properties. For instance, if
-the DS reorders messages from a Client or provides different Clients
-with inconsistent orderings, then Clients can to detect this
+the DS reorders messages from a client or provides different clients
+with inconsistent orderings, then clients can detect this
 misconduct. However, MLS need not provide mechanisms to recover from a
 misbehaving DS.
 
 Note that some forms of DS misbehavior are still possible and
 difficult to detect. For instance, a DS can simply refuse
-to relay messages to and from a given Client. Without some
-sort of side information, other Clients cannot generally
-distinguish this form of Denial of Service (DoS) attack
-from the Client being actually offline.
+to relay messages to and from a given client. Without some
+sort of side information, other clients cannot generally
+distinguish this form of Denial of Service (DoS) attack.
 
 ### Membership knowledge
 
 Group membership is itself sensitive information and MLS is designed
 so that neither the DS nor the AS need have static knowledge
-of which Clients are in which Group. However, they may learn
+of which clients are in which group. However, they may learn
 this information through traffic analysis. For instance, in
-a server side fanout model, the DS learns that a given Client
-is sending the same message to a set of other Clients. In addition,
-there may be applications of MLS in which the Group membership
+a server side fanout model, the DS learns that a given client
+is sending the same message to a set of other clients. In addition,
+there may be applications of MLS in which the group membership
 list is stored on some server associated with the MS.
-
 
 ### Membership and offline members
 
 Because Forward Secrecy (FS) and Post-Compromise Security (PCS)
 rely on the deletion and replacement of keying material,
-any Client which is persistently offline
+any client which is persistently offline
 may still be holding old keying material and thus be a threat
 to both FS and PCS if it is later compromised.
 MLS does not inherently defend against this problem, but
 MLS-using systems can enforce some mechanism for doing
-so. Typically this will consist of evicting Clients which
+so. Typically this will consist of evicting clients which
 are idle for too long, thus containing the threat of
 compromise. The precise details of such mechanisms are
 a matter of local policy and beyond the scope of this document.
-
 
 
 # System Requirements
@@ -388,13 +388,13 @@ a matter of local policy and beyond the scope of this document.
 
 MLS is designed as a large scale group messaging protocol and hence aims to
 provide performance and safety to its users.  Messaging systems that implement
-MLS provide support for conversations involving two or more participants,
-and aim to scale to approximately 50,000 clients, typically including many
-Members using multiple devices.
+MLS provide support for conversations involving two or more members,
+and aim to scale to approximately 50,000 members, typically including many
+users using multiple devices.
 
 ### Asynchronous Usage
 
-No operation in MLS requires two distinct users to be online
+No operation in MLS requires two distinct users or clients to be online
 simultaneously. In particular, clients participating in conversations protected
 using MLS can update shared keys, add or remove new members, and
 send messages and attachments without waiting for another user's reply.
@@ -411,11 +411,11 @@ does not result in permanent exclusion from the group.
 
 ### Support for Multiple Devices
 
-It is typically expected for Members of the Group to own different devices.
+It is typically expected for users within Group to own different devices.
 
-A new device can join the group and will be considered as a new Client by
-the protocol. This Client will not gain access to the history even if
-it is owned by someone who is already a Member of the Group.
+A new device can be added to a group by sharing of an existing client secrets
+or be considered as a new client by the protocol. This client will not gain access
+to the history even if it is owned by someone who owns another member of the Group.
 Restoring history is typically not allowed at the protocol level but applications
 can elect to provide such a mechanism outside of MLS.
 
@@ -438,9 +438,8 @@ messages forwarded by the DS, with the initial public keys signed by the AS.
 
 The protocol aims to be compatible with federated environments. While this
 document does not specify all necessary mechanisms required for federation,
-multiple MLS implementations can interoperate and to form federated systems if
+multiple MLS implementations can interoperate to form federated systems if
 they use compatible wire encodings.
-
 
 ### Compatibility with future versions of MLS
 
@@ -464,7 +463,7 @@ goals ("MLS aims to guarantee that...")?]]
 We assume that all transport connections are secured via some transport
 layer security mechanism such as TLS {{?I-D.ietf-tls-tls13}}. However,
 as noted above, the security of MLS will generally survive compromise
-of the transport layer, so long as identities provided by the AS are
+of the transport layer, so long as identity keys provided by the AS are
 authenticated at a minimum.
 
 ### Message Secrecy and Authentication {#message-secrecy-authentication}
@@ -472,24 +471,24 @@ authenticated at a minimum.
 The trust establishment step of the MLS protocol is followed by a
 conversation protection step where encryption is used by clients to
 transmit authenticated messages to other clients through the DS.
-This ensures that the DS does not have access to the Group's private content.
+This ensures that the DS does not have access to the group's private content.
 
-MLS aims to provide Secrecy, Integrity and Authentication for all messages.
+MLS aims to provide secrecy, integrity and authentication for all messages.
 
 Message Secrecy in the context of MLS means that only intended recipients
 (current group members), can read any message sent to the group,
 even in the context of an active adversary as described in the threat model.
 
-Message Integrity and Authentication mean that an honest Client can only
-accept a message if it was sent by a group member and that one Client
-cannot send a message which other Clients accept as being from another
-Client.
+Message Integrity and Authentication mean that an honest client can only
+accept a message if it was sent by a group member and that a client
+cannot send a message which other clients would accept as being from a
+different client.
 
 A corollary to this statement is that the AS and the DS cannot read the
-content of messages sent between Members as they are not Members of the
-Group. MLS optionally provides additional protections regarding traffic
-analysis so as to reduce the ability of adversaries, or a compromised
-member of the messaging system, to deduce the content of the messages
+content of messages sent between members as they are not members of the
+group. MLS optionally provides additional protections regarding traffic
+analysis so as to reduce the ability of adversaries, to deduce the content
+of the messages
 depending on (for example) their size. One of these protections includes
 padding messages in order to produce ciphertexts of standard
 length. While this protection is highly recommended it is not
@@ -508,19 +507,19 @@ Forward Secrecy (FS) and Post-Compromise Security (PCS).
 FS means that access to all encrypted traffic history combined
 with an access to all current keying material on clients will not
 defeat the secrecy properties of messages older than the oldest key of
-the client.
+the compromised client.
 Note that this means that clients have the extremely important role
 of deleting appropriate keys as soon as they have been used with
 the expected message, otherwise the secrecy of the messages and the
 security for MLS is considerably weakened.
 
-PCS means that if a group member is compromised at some time t but
-subsequently performs an update at some time t', then all MLS guarantees
-apply to messages sent after time t'. For example, if an adversary learns all
-secrets known to Alice at time t, including both Alice's secret keys and all
-shared group keys, but Alice performs a key update at time t', then the
-adversary is unable to violate any of the MLS security properties after
-time t'.
+PCS means that if a group member is compromised at some time T but
+subsequently performs an update at some time T', then all MLS guarantees
+apply to messages sent after time T'. For example, if an adversary learns all
+secrets known to Alice at time T, including both Alice's secrets and all
+shared group secrets, but Alice performs a key update at time T', which
+is not under the control of the adversary, then the adversary is unable
+to violate any of the MLS security properties after time T'.
 
 Both of these properties are satisfied even against compromised
 DSs and ASs.
@@ -531,13 +530,13 @@ MLS aims to provide agreement on group membership, meaning that all
 group members have agreed on the list of current group members.
 
 Some applications may wish to enforce ACLs to limit addition or removal
-of group members, to privileged users. Others may wish to require
+of group members, to privileged clients or users. Others may wish to require
 authorization from the current group members or a subset thereof.
 Regardless, MLS does not allow addition or removal of group members
 without informing all other members.
 
-Once a Member is part of a Group, the set of devices controlled by the
-member can only be altered by an authorized member of the group.
+Once a client is part of a group, the set of devices controlled by the
+user can only be altered by an authorized member of the group.
 This authorization could depend on the application: some applications
 might want to allow certain other members of the group to add or
 remove devices on behalf of another member, while other applications
@@ -546,7 +545,8 @@ devices to add or remove them at the potential cost of weaker PCS guarantees.
 
 Members who are removed from a group do not enjoy special privileges:
 compromise of a removed group member does not affect the security
-of messages sent after their removal.
+of messages sent after their removal but might affect previous messages
+if the group secrets have not been deleted properly.
 
 #### Security of Attachments
 
@@ -565,13 +565,13 @@ In general we do not consider Denial of Service (DoS) resistance to be the respo
 of the protocol. However, it should not be possible for anyone aside from the DS to
 perform a trivial DoS attack from which it is hard to recover.
 
-#### Non-Repudiation and Deniability
+#### Non-Repudiation vs Deniability
 
-As described in {{client-compromise}}, MLS provides data origin authentication
-within a group, such that one group member cannot send a message that appears
+As described in {{client-compromise}}, MLS provides strong authentication
+within a group, such that a group member cannot send a message that appears
 to be from another group member. Additionally, some services require that a
 recipient be able to prove to the messaging service that a message was
-sent by a given Client, in order to report abuse. MLS supports
+sent by a given client, in order to report abuse. MLS supports
 both of these use cases. In some deployments, these services are provided
 by mechanisms which allow the receiver to prove a message's origin
 to a third party (this if often called "non-repudiation"), but it
@@ -588,7 +588,7 @@ to provide the security services described in in the face of such attackers.
 In addition,
 these guarantees are intended to degrade gracefully in the presence
 of compromise of the transport security links as well as of
-both Clients and elements of the messaging
+both clients and elements of the messaging
 system, as described in the remainder of this section.
 
 ## Transport Security Links
@@ -601,20 +601,20 @@ system, as described in the remainder of this section.
 MLS is intended to provide strong guarantees in the face of compromise
 of the DS. Even a totally compromised DS should not be able to read
 messages or inject messages that will be acceptable to legitimate
-Clients. It should also not be able to undetectably remove, reorder
+clients. It should also not be able to undetectably remove, reorder
 or replay messages.
 
 However, a DS can mount a variety of DoS attacks on the system,
 including total DoS attacks (where it simply refuses to forward any
 messages) and partial DoS attacks (where it refuses to forward
-messages to and from specific Clients). As noted in
+messages to and from specific clients). As noted in
 {{delivery-guarantees}}, these attacks are only partially detectable
 by clients without an out-of-band channel. Ultimately, failure of
 the DS to provide reasonable service must be dealt with as a customer
 service matter, not via technology.
 
 Because the DS is responsible for providing the initial keying
-material to Clients, it can provide stale keys. This does not
+material to clients, it can provide stale keys. This does not
 inherently lead to compromise of the message stream, but does
 allow it to attack forward security to a limited extent.
 This threat can be mitigated by having initial keys expire.
@@ -630,20 +630,20 @@ MLS will only provide limited security against a compromised AS.
 ## Client Compromise
 
 In general, MLS only provides limited protection against compromised
-Clients. When the Client is compromised, then the attacker will
+clients. When the client secrets are compromised, then the attacker will
 obviously be able to decrypt any messages for groups in which the
-Client is a member. It will also be able to send messages
-impersonating the compromised Client until the Client updates its
+client is a member. It will also be able to send messages
+impersonating the compromised client until the client updates its
 keying material (see {{fs-and-pcs}}).
 MLS attempts to provide some security in the face of client
 compromise.
 
-In addition, a Client cannot send a message to a group which appears to
-be from another Client with a different identity. Note that if Clients
-from the same Member share keying material, then one will be able to
+In addition, a client cannot send a message to a group which appears to
+be from another client with a different identity. Note that if devices
+from the same user share keying material, then one will be able to
 impersonate another.
 
-Finally, Clients should not be able to perform DoS attacks {{denial-of-service}}.
+Finally, clients should not be able to perform DoS attacks {{denial-of-service}}.
 
 # IANA Considerations
 
@@ -670,5 +670,3 @@ This document makes no requests of IANA.
 * Raphael Robert \\
   Wire \\
   raphael@wire.com
-
-


### PR DESCRIPTION
Mostly lowercase everything and fixes a few misuses of "member" that were to restrictive.