### PR TITLE
Edit pass on Abstract, Introduction, and General Setting

### DIFF
--- a/draft-ietf-mls-architecture.md
+++ b/draft-ietf-mls-architecture.md
@@ -44,40 +44,6 @@ author:
     email: alan@wire.com
 
 informative:
-  MLSPROTO:
-       title: "Messaging Layer Security Protocol"
-       date: 2018
-       author:
-         -  ins: R. Barnes
-            name: Richard Barnes
-            organization: Cisco
-            email: rlb@ipv.sx
-         -
-            ins: B. Beurdouche
-            name: Benjamin Beurdouche
-            organization: Inria
-            email: benjamin.beurdouche@inria.fr
-         -
-            ins: J. Millican
-            name: Jon Millican
-            organization: Facebook
-            email: jmillican@fb.com
-         -
-            ins: E. Omara
-            name: Emad Omara
-            organization: Google
-            email: emadomara@google.com
-         -
-            ins: K. Cohn-Gordon
-            name: Katriel Cohn-Gordon
-            organization: University of Oxford
-            email: me@katriel.co.uk
-         -
-            ins: R. Robert
-            name: Raphael Robert
-            organization: Wire
-            email: raphael@wire.com
-
   KeyTransparency:
        target: https://KeyTransparency.org
        title: Key Transparency
@@ -89,7 +55,7 @@ informative:
 
 --- abstract
 
-The Messaging Layer Security (MLS) protocol {{MLSPROTO}} document has
+The Messaging Layer Security (MLS) protocol {{!I-D.ietf-mls-protocol}} specification has
 the role of defining a Group Key Agreement, all the necessary
 cryptographic operations, and serialization/deserialization functions
 necessary to create a scalable and secure group messaging protocol.
@@ -98,11 +64,11 @@ message forgery, and provide good properties such as forward-secrecy
 (FS) and post-compromise security (PCS) in the case of past or future
 device compromises.
 
-This document, on the other hand is intended to describe a general
+This document describes a general
 secure group messaging infrastructure and its security goals.  It
 provides guidance on building a group messaging system and discusses
 security and privacy tradeoffs offered by multiple security mechanism
-that are part of the MLS protocol (ie. frequency of public encryption
+that are part of the MLS protocol (e.g., frequency of public encryption
 key rotation).
 
 The document also extends the guidance to parts of the infrastructure
@@ -110,9 +76,9 @@ that are not standardized by the MLS Protocol document and left to the
 application or the infrastructure architects to design.
 
 While the recommendations of this document are not mandatory to follow
-in order to interoperate at the protocol level, most will vastly
-influence the overall security guarantees that are achieved by the
-overall messaging system. This is especially true in case of active
+in order to interoperate at the protocol level,
+they affect the overall security guarantees that are achieved by a
+messaging application. This is especially true in case of active
 adversaries that are able to compromise clients, the delivery service
 or the authentication service.
 
@@ -128,32 +94,21 @@ Instructions are on that page as well.  Editorial changes can be
 managed in GitHub, but any substantive change should be discussed on
 the MLS mailing list.
 
-DISCLAIMER: A lot of work is still ongoing on the current version of
-this draft. Especially, this preliminary writing of the security
-considerations has not been reviewed by the working group yet and
-might contain errors.
-Please file an issue on the document's GitHub if you find errors.
-
-[[TODO: Remove disclaimer.]]
-
 End-to-end security is a requirement for instant messaging systems and
 is commonly deployed in many such systems. In this context,
 "end-to-end" captures the notion that users of the system enjoy some
 level of security -- with the precise level depending on the system
-design -- even when the service provider they are using performs
-unsatisfactorily.
+design -- even in the face of malicious actions by the operator of the messaging
+system.
 
 Messaging Layer Security (MLS) specifies an architecture (this
-document) and an abstract protocol {{MLSPROTO}} for providing
+document) and a protocol {{!I-D.ietf-mls-protocol}} for providing
 end-to-end security in this setting. MLS is not intended as a full
 instant messaging protocol but rather is intended to be embedded in
-concrete protocols, such as XMPP {{?RFC6120}}. In addition, it does not
-specify a complete wire encoding, but rather a set of abstract data
-structures which can then be mapped onto a variety of concrete
-encodings, such as TLS {{?RFC8446}}, CBOR {{?RFC7049}}, and
-JSON {{?RFC7159}}.  Implementations which adopt compatible encodings
-will have some degree of interoperability at the message level, though
-they may have incompatible identity/authentication infrastructures.
+concrete protocols, such as XMPP {{?RFC6120}}.  Implementations of the MLS
+protocol will interoperate at the cryptographic level, though
+they may have incompatibilities in terms of how protected messages are
+delivered, contents of protected messages, and identity/authentication infrastructures.
 The MLS protocol has been designed to provide the same security
 guarantees to all users, for all group sizes, even when it reduces to
 only two users.

--- a/draft-ietf-mls-architecture.md
+++ b/draft-ietf-mls-architecture.md
@@ -251,15 +251,14 @@ public values such as a name (an identity), a public encryption key
 and a public signature key. Ownership of a client by a user is
 determined by the fact that the user has knowledge of the
 associated secret values. When a client is part of a Group, it is
-called a Member and its signature key pair uniquely identifies it
-to other clients or members in the Group.
+called a Member.
 In some messaging systems, clients belonging to the same user must
 all share the same signature key pair, but MLS does not assume this.
 
-Users will often use multiple clients, potentially one or more per
-device (phones, web clients or other devices...), and may
-choose to authenticate using the same signature key across devices,
-using one signature key per device or even one signature key per group.
+Users will often use multiple devices, e.g., a phone as well as a laptop.
+Different devices may be represented as different clients, with independent
+cryptographic state, or they may share cryptographic state, relying on some
+application-provided mechanism to sync across devices.
 
 The formal definition of a Group in MLS is the set of clients that
 have knowledge of the shared group secret established in the group key

--- a/draft-ietf-mls-architecture.md
+++ b/draft-ietf-mls-architecture.md
@@ -128,13 +128,13 @@ The Service Provider presents two abstract functionalities that allow
 clients to prepare for sending and receiving messages securely:
 
 - An Authentication Service (AS) functionality which is responsible
-  for maintaining a binding between a unique identifier (identity) and
-  the public key material (credential) used for authentication in the
-  MLS protocol. This functionality must also be able to generate these
-  credentials or validate them if they are provided by MLS clients.
+  for attesting to bindings between application-meaningful identifiers and
+  the public key material used for authentication in the
+  MLS protocol. This functionality must also be able to generate
+  credentials that encode these bindings and validate credentials provided by MLS clients.
 
 - A Delivery Service (DS) functionality which can receive and
-  redistributing messages between group members. In the case of group
+  distribute messages between group members. In the case of group
   messaging, the delivery service may also be responsible for acting
   as a "broadcaster" where the sender sends a single message which is
   then forwarded to each recipient in the group by the DS. The DS is
@@ -205,7 +205,7 @@ scenario might look like this:
 4. Bob and/or Charlie respond to Alice's message. In addition, they
    might choose to update their key material which provides
    post-compromise security {{fs-and-pcs}}. As a consequence of that
-   change, the group secrets are updated
+   change, the group secrets are updated.
 
 Clients may wish to do the following:
 
@@ -251,13 +251,13 @@ public values such as a name (an identity), a public encryption key
 and a public signature key. Ownership of a client by a user is
 determined by the fact that the user has knowledge of the
 associated secret values. When a client is part of a Group, it is
-called a Member and its signature key pair uniquely defines its
-identity to other clients or members in the Group.
+called a Member and its signature key pair uniquely identifies it
+to other clients or members in the Group.
 In some messaging systems, clients belonging to the same user must
-all share the same identity key pair, but MLS does not assume this.
+all share the same signature key pair, but MLS does not assume this.
 
-Users will typically own multiple clients, potentially one or more per
-end-user devices (phones, web clients or other devices...) and may
+Users will often use multiple clients, potentially one or more per
+device (phones, web clients or other devices...), and may
 choose to authenticate using the same signature key across devices,
 using one signature key per device or even one signature key per group.
 


### PR DESCRIPTION
Mainly focused on cleaning up grammar, but also fixing some things that have gone stale, like the idea that the MLS protocol is "abstract".