### PR TITLE
Revise the DS section

### DIFF
--- a/draft-ietf-mls-architecture.md
+++ b/draft-ietf-mls-architecture.md
@@ -478,7 +478,7 @@ both of the following examples provide a unique Commit per epoch:
 * A "filtering server" Delivery Service where a server rejects all but the
   first Commit for an epoch and clients apply each Commit they receive.
 
-* An "ordered server" Delivery Service where a server forwards all messages
+* An "ordering server" Delivery Service where a server forwards all messages
   but assures that all clients see Commits in the same order, and clients.
 
 * A "passive server" Delivery Service where a server forwards all messages

--- a/draft-ietf-mls-architecture.md
+++ b/draft-ietf-mls-architecture.md
@@ -475,7 +475,7 @@ server and client components. Acheiving required uniqueness property will
 typically require a combination of client and server behaviors.  For example,
 both of the following examples provide a unique Commit per epoch:
 
-* An "filtering server" Delivery Service where a server rejects all but the
+* A "filtering server" Delivery Service where a server rejects all but the
   first Commit for an epoch and clients apply each Commit they receive.
 
 * An "ordered server" Delivery Service where a server forwards all messages

--- a/draft-ietf-mls-architecture.md
+++ b/draft-ietf-mls-architecture.md
@@ -473,7 +473,7 @@ Service must transmit to the group exactly one Commit message per epoch.
 Much like the Authentication Service, the Delivery Service can be split between
 server and client components. Acheiving required uniqueness property will
 typically require a combination of client and server behaviors.  For example,
-both of the following examples provide a unique Commit per epoch:
+all of the following examples provide a unique Commit per epoch:
 
 * A "filtering server" Delivery Service where a server rejects all but the
   first Commit for an epoch and clients apply each Commit they receive.

--- a/draft-ietf-mls-architecture.md
+++ b/draft-ietf-mls-architecture.md
@@ -471,7 +471,7 @@ Each Commit is premised on a given state or "epoch" of the group.  The Delivery
 Service must transmit to the group exactly one Commit message per epoch.
 
 Much like the Authentication Service, the Delivery Service can be split between
-server and client components. Acheiving required uniqueness property will
+server and client components. Achieving the required uniqueness property will
 typically require a combination of client and server behaviors.  For example,
 all of the following examples provide a unique Commit per epoch:
 

--- a/draft-ietf-mls-architecture.md
+++ b/draft-ietf-mls-architecture.md
@@ -425,7 +425,7 @@ cryptographic information:
 * The client's asymmetric encryption public key material.
 
 All the parameters in the KeyPackage are signed with the signature private key
-corresponding to to the credential.
+corresponding to the credential.
 
 As noted above, users may own multiple clients, each with their
 own keying material, and thus there may be multiple entries

--- a/draft-ietf-mls-architecture.md
+++ b/draft-ietf-mls-architecture.md
@@ -481,7 +481,7 @@ both of the following examples provide a unique Commit per epoch:
 * An "ordered server" Delivery Service where a server forwards all messages
   but assures that all clients see Commits in the same order, and clients.
 
-* A "passive server" Delivery Service where a servier forwards all messages
+* A "passive server" Delivery Service where a server forwards all messages
   without ordering or reliability guarantees, and clients execute some secondary
   consensus protocol to choose among the Commits received in a window.
 

--- a/draft-ietf-mls-architecture.md
+++ b/draft-ietf-mls-architecture.md
@@ -372,20 +372,23 @@ signature of the message.
 The Delivery Service (DS) is expected to play multiple roles in the
 Service Provider architecture:
 
-* To act as a directory service providing the initial keying material
+* Acting as a directory service providing the initial keying material
   for clients to use.
   This allows a client to establish a shared key and send encrypted
   messages to other clients even if the other client is offline.
 
-* To route messages between clients and to act as a message
-  broadcaster, taking in one message and forwarding it to multiple
-  clients (also known as "server side fanout").
+* Routing MLS messages between clients.
+
+Some MLS messages need only be delivered to some members of group (e.g., the
+message initializing a new member's state), while others need to be delivered to
+all members.  A DS may enable these delivery patterns via unicast channels
+(sometimes known as "client fanout"), broadcast channels ("server fanout"), or a
+mix of both.
 
 Because the MLS protocol provides a way for clients to send and receive
 application messages asynchronously, it only provides causal
 ordering of application messages from senders while it has to enforce
 global ordering of group operations to provide Group Agreement.
-[[TODO: Casual ordering?]]
 
 Depending on the level of trust given by the group to the Delivery
 Service, the functional and privacy guarantees provided by MLS may

--- a/draft-ietf-mls-architecture.md
+++ b/draft-ietf-mls-architecture.md
@@ -92,7 +92,7 @@ informative:
       author:
         -
           ins: A.M. Piotrowska
-          name: Ania M. Piotrowska 
+          name: Ania M. Piotrowska
         -
           ins: J. Hayes
           name: Jamie Hayes


### PR DESCRIPTION
This edit got a little invasive, largely around the "ordering" requirements.  As was already pointed out the epoch numbering provides ordering to first order.  What is really needed is for the DS to select a single Commit per epoch.