### PR TITLE
Add references to academic work

### DIFF
--- a/draft-ietf-mls-architecture.md
+++ b/draft-ietf-mls-architecture.md
@@ -1376,6 +1376,32 @@ specification, which remains non-trivial.
 > clients from physical compromise. In such setting, HSMs and secure
 > enclaves can be used to protect signature keys.
 
+## Cryptographic Analysis of the MLS Protocol
+
+Various academic works have analyzed MLS and the different security guarantees
+it aims to provide. The security of large parts of the protocol has been
+analyzed by [BBN19] (draft 7), [ACDT21] (draft 11) and [AJM20] (draft 12).
+
+Individual components of various drafts of the MLS protocol have been analyzed in
+isolation and with differing adversarial models, for example, [BBR18], [ACDT19],
+[ACCKKMPPWY19], [AJM20] and [ACJM20] analyze the ratcheting tree as the
+sub-protocol of MLS that facilitates key agreement, while [BCK21] analyzes the
+key derivation paths in the ratchet tree and key schedule. Finally, [CHK19]
+analyzes the authentication and cross-group healing guarantees provided by MLS.
+
+# Informative References
+
+* ACDT19: https://eprint.iacr.org/2019/1189
+* ACCKKMPPWY19: https://eprint.iacr.org/2019/1489
+* ACJM20: https://eprint.iacr.org/2020/752
+* AJM20: https://eprint.iacr.org/2020/1327
+* ACDT21: https://eprint.iacr.org/2021/1083
+* AHKM21: https://eprint.iacr.org/2021/1456
+* CHK19: https://eprint.iacr.org/2021/137
+* BCK21: https://eprint.iacr.org/2021/137
+* BBR18: https://hal.inria.fr/hal-02425247
+* BBN19: https://hal.laas.fr/INRIA/hal-02425229
+
 # IANA Considerations
 
 This document makes no requests of IANA.


### PR DESCRIPTION
This PR adds a short paragraph referencing the various academic works that has gone into MLS. 

The references to the various works still need to be cleaned up, which I will do once the list is complete. In particular, each reference needs to be checked for correctness (eprint version vs. publicized version) and then included as informal reference in the yaml header of the document.