### PR TITLE
Revert "Discuss content framing and negotiation"

### DIFF
--- a/draft-ietf-mls-architecture.md
+++ b/draft-ietf-mls-architecture.md
@@ -647,20 +647,7 @@ information about their capabilities.  Groups can also have extension data
 associated with them, and the group agreement properties of MLS will confirm that
 all members of the group agree on the content of these extensions.
 
-## Application Data Framing and Negotiation
-
-Application messages carried by MLS are opaque to the protocol; they can contain
-arbitrary data. Each application which uses MLS needs to define the format of its
-`application_data` and any mechanism necessary to negotiate the format of that
-content over the lifetime of an MLS group. In many applications this means
-managing format migrations for groups with multiple members who may each be
-offline at unpredictable times.
-
-> **RECOMMENDATION:**
-> Use the default content mechanism defined in {{?I-D.mahy-mls-content-neg}},
-> unless the specific application defines another mechanism which more
-> appropriately addresses the same requirements for that application of MLS.
-
+Application messages carried by MLS are opaque; they can contain arbitrary data.
 The MLS framing for application messages also provides a field where clients can
 send information that is authenticated but not encrypted.  Such information can
 be used by servers that handle the message, but group members are assured that


### PR DESCRIPTION
Reverts mlswg/mls-architecture#94

This has not been merged for a reason, namely I don’t want the dependency on an unpublished draft.