### PR TITLE
WGLC changes in Privacy Considerations section.

### DIFF
--- a/draft-ietf-mls-architecture.md
+++ b/draft-ietf-mls-architecture.md
@@ -85,6 +85,26 @@ informative:
     refcontent:
       - "Symposium on Principles of Distributed Computing (PODC)"
 
+  Loopix
+    title: "The Loopix Anonymity System"
+    date: 2017
+    author:
+      -
+        ins: A.M. Piotrowska
+        name: Ania M. Piotrowska
+      -
+        ins: J. Hayes
+        name: Jamie Hayes
+      -
+        ins: T. Elahi
+        name: Tariq Elahi
+      -
+        ins: S. Meiser
+        name: Sebastian Meiser
+      -
+        ins: G. Danezis
+        name: George Danezis
+
 --- abstract
 
 The Messaging Layer Security (MLS) protocol {{!I-D.ietf-mls-protocol}}
@@ -1516,7 +1536,7 @@ confidentiality guarantees, it is a serious issue for privacy.
 > **RECOMMENDATION:**
 > In the case where metadata has to be persisted for functionality, it should be
 > stored encrypted at rest and during the execution. Applications should also
-> consider anonymous systems for server fanout.
+> consider anonymous systems for server fanout (for example {{Loopix}}).
 
 Often, expectation from users is that the infrastructure will not retain the
 ability to constantly map the user identity to signature public keys of the MLS

--- a/draft-ietf-mls-architecture.md
+++ b/draft-ietf-mls-architecture.md
@@ -85,7 +85,7 @@ informative:
     refcontent:
       - "Symposium on Principles of Distributed Computing (PODC)"
 
-  Loopix
+  Loopix:
     title: "The Loopix Anonymity System"
     date: 2017
     author:

--- a/draft-ietf-mls-architecture.md
+++ b/draft-ietf-mls-architecture.md
@@ -1452,7 +1452,7 @@ One thing for which the MLS Protocol is designed for is to make sure that all
 clients know who is in the group at all times. This means that - if all Members
 of the group and the Authentication Service are honest - no other parties than
 the members of the current group can read and write messages protected by the
-protocol for that Group. Note that when BasicCredential is used, the
+protocol for that Group. Note that when a `basic` Credential is used, the
 Authentication Service also needs an out-of-band mechanism to verify the
 identity asserted in the Credential.
 
@@ -1467,7 +1467,7 @@ Credential type used. For example, cryptographic verification of credentials
 can be largely performed autonomously on the clients for the `x509`
 Credential type. In contrast, when MLS clients use the `basic` Credential type,
 a larger degree of trust must be placed in a (likely) centralized
-authentication resource.
+authentication resource, or on out-of-band processes such as manual verification.
 
 While this service is often very well protected from external attackers, it
 might be the case that this service is compromised.  In such infrastructure, the


### PR DESCRIPTION
WGLC comments on Security Considerations Section

- Added discussion about significance of `basic` vs. `x509` credential types.
- Moved a paragraph about transport security in general into that section.
- Made text with list of metadata consistent with the metadata that is actually present in the protocol now.
- Moved Metadata Protection for Unencrypted Group Operations heading to just before the two paragraphs that actually discuss it.
- Added subsection "Integrity and Authentication of Custom Metadata" before the discussion about adding custom metadata to the AAD field.
- Noted that a websocket connection directly to the DS can be used instead of mobile host platform (ex: Apple, Google) native notifications in some environments.
- Fixed some typos.