### PR TITLE
Remove cites to non-app layer secure transports.

### DIFF
--- a/draft-ietf-mls-architecture.md
+++ b/draft-ietf-mls-architecture.md
@@ -202,26 +202,6 @@ informative:
         ins: G. Danezis
         name: George Danezis
 
-  TOR:
-    title: "Tor: The Second-Generation Onion Router"
-    date: 2004
-    author:
-      -
-        name: Roger Dingledine
-      -
-        name: Nick Mathewson
-      -
-        name: Paul Syverson
-    target: https://svn.torproject.org/svn/projects/design-paper/tor-design.html
-
-  WireGuard:
-    title: "WireGuard: Next Generation Kernel Network Tunnel"
-    date: 2020
-    author:
-        name: Jason Donenfeld
-    target: https://www.wireguard.com/papers/wireguard.pdf
-
-
 
 
 --- abstract
@@ -1074,10 +1054,10 @@ achieved in specific architecture designs.
 ## Assumptions on Transport Security Links
 
 As discussed above, MLS provides the highest level of security when its messages
-are delivered over a secure transport.  Any secure channel can be used as a
-transport layer to protect MLS messages, such as QUIC {{?RFC9000}}, TLS
-{{?RFC8446}}, IPsec {{?RFC6071}}, WireGuard {{WireGuard}}, or TOR
-{{TOR}}. However, the MLS protocol is designed to consider the following
+are delivered over a secure transport.  Any secure channel,
+such as QUIC {{?RFC9000}}, TLS {{?RFC8446}}, can be used to
+transport MLS messages.
+However, the MLS protocol is designed to consider the following
 threat-model:
 
 - The attacker can read, write, and delete arbitrary messages inside the secure


### PR DESCRIPTION
There have been a lot of comments about the inclusion of WireGuard and Tor as potential secure transports, but I actually think it's confusing to cite IPsec as well for layering issues. We don't have a real praxis for using things that aren't application-layer style protocols for protecting this kind of traffic, so I don't think we should encourage these. I've trimmed it to just QUIC and TLS.