### PR TITLE
Add link to e2e security definition draft

### DIFF
--- a/draft-ietf-mls-architecture.md
+++ b/draft-ietf-mls-architecture.md
@@ -251,7 +251,7 @@ In this context, "end-to-end" captures
 the notion that users of the system enjoy some level of security -- with the
 precise level depending on the system design -- even in the face of malicious
 actions by the operator of the messaging system. See
-{{!I-D.draft-knodel-e2ee-definition}} for a more detailed definition of
+{{?I-D.draft-knodel-e2ee-definition}} for a more detailed definition of
 end-to-end security.
 
 Messaging Layer Security (MLS) specifies an architecture (this document) and a

--- a/draft-ietf-mls-architecture.md
+++ b/draft-ietf-mls-architecture.md
@@ -250,7 +250,9 @@ and also deployed in systems for other purposes such as calling and conferencing
 In this context, "end-to-end" captures
 the notion that users of the system enjoy some level of security -- with the
 precise level depending on the system design -- even in the face of malicious
-actions by the operator of the messaging system.
+actions by the operator of the messaging system. See
+{{!I-D.draft-knodel-e2ee-definition}} for a more detailed definition of
+end-to-end security.
 
 Messaging Layer Security (MLS) specifies an architecture (this document) and a
 protocol {{!I-D.ietf-mls-protocol}} for providing end-to-end security in this


### PR DESCRIPTION
As briefly discussed during the interim, this PR adds a link to [draft-knodel-e2ee-definition](https://datatracker.ietf.org/doc/draft-knodel-e2ee-definition/). I hope I got the markdown link formatting right.