### PR TITLE
Retrieve initial keying material from DS, not AS

### DIFF
--- a/draft-ietf-mls-architecture.md
+++ b/draft-ietf-mls-architecture.md
@@ -404,7 +404,7 @@ sender can use a new key.
 
 ## Step 3: Adding Bob go the Group
 
-When Alice wants to create a group including Bob, she first uses the AS to look
+When Alice wants to create a group including Bob, she first uses the DS to look
 up his initial keying material. She then generates two messages:
 
 * A message to the entire group (which at this point is just her and Bob)
@@ -422,7 +422,7 @@ to receive it.
 ## Step 4: Adding Charlie to the Group
 
 If Alice then wants to add Charlie to the group, she follows a similar procedure
-as with Bob: she first uses the AS to look
+as with Bob: she first uses the DS to look
 up his initial keying material and then generates two messages:
 
 * A message to the entire group (consisting of her, Bob, and Charlie) adding

--- a/draft-ietf-mls-architecture.md
+++ b/draft-ietf-mls-architecture.md
@@ -402,7 +402,7 @@ can be reused for multiple senders, in order to provide forward secrecy
 it is better for this material to be regularly refreshed so that each
 sender can use a new key.
 
-## Step 3: Adding Bob go the Group
+## Step 3: Adding Bob to the Group
 
 When Alice wants to create a group including Bob, she first uses the DS to look
 up his initial keying material. She then generates two messages:


### PR DESCRIPTION
Section 5 denotes the DS is responsible for providing the initial keying material: 

> As a directory service providing the initial keying material for clients to use. This allows a client to establish a shared key and send encrypted messages to other clients even if they're offline.