### PR TITLE
fix figure 2

### DIFF
--- a/draft-ietf-mls-architecture.md
+++ b/draft-ietf-mls-architecture.md
@@ -401,15 +401,15 @@ Initial Keying Material ----------------------------------->     |
           Initial Keying Material ------------------------->     | Step 2
                     Initial Keying Material --------------->     |
 
-Get Bob Initial Keying Material ---------------->                |
-<-------------------- Bob Initial Keying Material                |
+Get Bob Initial Keying Material --------------------------->     |
+<------------------------------- Bob Initial Keying Material     |
 Add Bob to Group ------------------------------------------>     | Step 3
 Welcome (Bob)---------------------------------------------->     |
           <-------------------------------- Add Bob to Group     |
           <----------------------------------- Welcome (Bob)     |
 
-Get Charlie Initial Keying Material ------------>                |
-<---------------- Charlie Initial Keying Material                |
+Get Charlie Initial Keying Material ----------------------->     |
+<--------------------------- Charlie Initial Keying Material     |
 Add Charlie to Group -------------------------------------->     |
 Welcome (Charlie) ----------------------------------------->     | Step 4
           <---------------------------- Add Charlie to Group     |


### PR DESCRIPTION
Hi,

I think there is a small mistake in [Figure 2](https://messaginglayersecurity.rocks/mls-architecture/draft-ietf-mls-architecture.html#figure-2), as it says in section [3.3](https://messaginglayersecurity.rocks/mls-architecture/draft-ietf-mls-architecture.html#section-3.3):

> When Alice wants to create a group including Bob, she first uses the DS to look up his initial keying material. 

The same is the case for section [3.4](https://messaginglayersecurity.rocks/mls-architecture/draft-ietf-mls-architecture.html#section-3.4)