### PR TITLE
Add recommendation for deletion of `init_key`s

### DIFF
--- a/draft-ietf-mls-architecture.md
+++ b/draft-ietf-mls-architecture.md
@@ -669,12 +669,13 @@ multiple groups before needing to upload more fresh KeyPackages.
 
 In order to avoid replay attacks and provide forward secrecy for messages sent
 using the initial keying material, KeyPackages are intended to be used only
-once. The Delivery Service is responsible for ensuring that each KeyPackage is
-only used to add its client to a single group, with the possible exception of a
-"last resort" KeyPackage that is specially designated by the client to be used
-multiple times. Clients are responsible for providing new KeyPackages as
-necessary in order to minimize the chance that the "last resort" KeyPackage will
-be used.
+once, and `init_key` is intended to be deleted by the client after decryption
+of the Welcome message. The Delivery Service is responsible for ensuring that
+each KeyPackage is only used to add its client to a single group, with the
+possible exception of a "last resort" KeyPackage that is specially designated
+by the client to be used multiple times. Clients are responsible for providing
+new KeyPackages as necessary in order to minimize the chance that the "last
+resort" KeyPackage will be used.
 
 > **RECOMMENDATION:** Ensure that "last resort" KeyPackages don't get used by
 > provisioning enough standard KeyPackages.
@@ -685,6 +686,10 @@ be used.
 
 > **RECOMMENDATION:** Ensure that the client for which a last resort KeyPackage
 > has been used is updating leaf keys as early as possible.
+
+> **RECOMMENDATION:** Ensure that clients delete their private `init_key` key
+> after processing a Welcome message, or after the rotation of "last resort"
+> KeyPackage.
 
 Overall, it needs to be noted that key packages need to be updated when
 signature keys are changed.


### PR DESCRIPTION
Because the `joiner_secret` is encrypted to the `init_key` of joiners, if the joiners don't delete their `init_key` after processing a Welcome, this could undermine forward-secrecy. I noticed that the document don't give any precise recommendations about that.

There are some hints scattered in the document, but they give recommendations to participants adding other participants, not to participants being added: https://github.com/mlswg/mls-architecture/blob/b091b3a30d6f9d2f46383f7bd152058f0fbfc9b1/draft-ietf-mls-architecture.md?plain=1#L670-L672

This PR adds a recommendation for that. I am not sure on how to proceed, I have made an attempt but it might belong to another section!