### PR TITLE
Update github action

### DIFF
--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -20,40 +20,39 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Checkout"
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
-    - name: "Cache Setup"
-      id: cache-setup
-      run: |
-        mkdir -p "$HOME"/.cache/xml2rfc
-        echo "::set-output name=path::$HOME/.cache/xml2rfc"
-        date -u "+::set-output name=date::%FT%T"
+    - name: "Setup"
+      id: setup
+      run: date -u "+date=%FT%T" >>"$GITHUB_OUTPUT"
 
-    - name: "Cache References"
-      uses: actions/cache@v2
+    - name: "Caching"
+      uses: actions/cache@v4
       with:
-        path: ${{ steps.cache-setup.outputs.path }}
-        key: refcache-${{ steps.cache-setup.outputs.date }}
-        restore-keys: |
-          refcache-${{ steps.cache-setup.outputs.date }}
-          refcache-
+        path: |
+          .refcache
+          .venv
+          .gems
+          node_modules
+          .targets.mk
+        key: i-d-${{ steps.setup.outputs.date }}
+        restore-keys: i-d-
 
     - name: "Build Drafts"
       uses: martinthomson/i-d-template@v1
+      with:
+        token: ${{ github.token }}
 
     - name: "Update GitHub Pages"
       uses: martinthomson/i-d-template@v1
       if: ${{ github.event_name == 'push' }}
       with:
         make: gh-pages
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ github.token }}
 
-    - name: "Save HTML"
-      uses: actions/upload-artifact@v2
+    - name: "Archive Built Drafts"
+      uses: actions/upload-artifact@v4
       with:
-        path: "*.html"
-
-    - name: "Save Text"
-      uses: actions/upload-artifact@v2
-      with:
-        path: "*.txt"
+        path: |
+          draft-*.html
+          draft-*.txt


### PR DESCRIPTION
The last two pull-requests failed because the version of `actions/upload-artifact` is too old (v2 instead of v4).
I have imported the new version of the action from [here](https://github.com/martinthomson/i-d-template/blob/main/template/.github/workflows/ghpages.yml) because the current `ghpages` workflow is adapted from [an old version (oct 2020) of it](https://github.com/martinthomson/i-d-template/blob/aa32825d42c99ef0eb7d40513379396f5af561ee/template/.github/workflows/ghpages.yml).