### PR TITLE
Disclaim replay protection

### DIFF
--- a/draft-ietf-mls-architecture.md
+++ b/draft-ietf-mls-architecture.md
@@ -2016,9 +2016,12 @@ the protocol to securely implement the specification, which remains non-trivial.
 
 # No Protection against Replay by Insiders
 
-MLS does not provide protections against replay of group messages by members 
-of the group.  Applications for whom replay is an important risk should apply 
-mitigations at the application layer, as discussed below.
+MLS does not protect against one group member replaying a PrivateMessage sent by another
+group member within the same epoch that the message was originally sent. Similarly, MLS
+does not protect against the replay (by a group member or otherwise) of a PublicMessage
+within the same epoch that the message was originally sent. Applications for
+whom replay is an important risk should apply mitigations at the application layer, as
+discussed below.
 
 In addition to the risks discussed in {{symmetric-key-compromise}}, an attacker 
 with access to the Ratchet Secrets for an endpoint can replay PrivateMessage 
@@ -2027,7 +2030,7 @@ message and re-encrypting it with a new generation of the original sender's
 ratchet.  If the other members of the group interpret a message with a new 
 generation as a fresh message, then this message will appear fresh.  (This is 
 possible because the message signature does not cover the `generation` field 
-of the message.)  Messages sent as PublicMessages objects similarly lack replay 
+of the message.)  Messages sent as PublicMessage objects similarly lack replay 
 protections.  There is no message counter comparable to the `generation` field 
 in PrivateMessage.
 

--- a/draft-ietf-mls-architecture.md
+++ b/draft-ietf-mls-architecture.md
@@ -2033,7 +2033,7 @@ in PrivateMessage.
 
 Applications can detect replay by including a unique identifier for the message 
 (e.g., a counter) in either the message payload or the `authenticated_data` 
-field, both of which are included in the signed message content in both 
+field, both of which are included in the signatures for
 PublicMessage and PrivateMessage.
 
 ## Cryptographic Analysis of the MLS Protocol

--- a/draft-ietf-mls-architecture.md
+++ b/draft-ietf-mls-architecture.md
@@ -2014,6 +2014,28 @@ the protocol to securely implement the specification, which remains non-trivial.
 > the MLS clients from physical compromise. In such settings, HSMs and secure
 > enclaves can be used to protect signature keys.
 
+# No Protection against Replay by Insiders
+
+MLS does not provide protections against replay of group messages by members 
+of the group.  Applications for whom replay is an important risk should apply 
+mitigations at the application layer, as discussed below.
+
+In addition to the risks discussed in {{symmetric-key-compromise}}, an attacker 
+with access to the Ratchet Secrets for an endpoint can replay PrivateMessage 
+objects sent by other members of the group by taking the signed content of the 
+message and re-encrypting it with a new generation of the original sender's 
+ratchet.  If the other members of the group interpret a message with a new 
+generation as a fresh message, then this message will appear fresh.  (This is 
+possible because the message signature does not cover the `generation` field 
+of the message.)  Messages sent as PublicMessages objects similarly lack replay 
+protections.  There is no message counter comparable to the `generation` field 
+in PrivateMessage.
+
+Applications can detect replay by including a unique identifier for the message 
+(e.g., a counter) in either the message payload or the `authenticated_data` 
+field, both of which are included in the signed message content in both 
+PublicMessage and PrivateMessage.
+
 ## Cryptographic Analysis of the MLS Protocol
 
 Various academic works have analyzed MLS and the different security guarantees


### PR DESCRIPTION
As [discussed on the MLS mailing list](https://mailarchive.ietf.org/arch/msg/mls/SRAV33J5Ka9A4R-Ymv8a_T_TXhE/), an attacker with access to the groups symmetric secrets can create a new PrivateMessage containing the content of a previously sent message, and a different generation value.  This PR clarifies that this sort of replay is not protected against by the protocol.