### PR TITLE
Add recommendation about KeyPackage expiration (alternative)

### DIFF
--- a/draft-ietf-mls-architecture.md
+++ b/draft-ietf-mls-architecture.md
@@ -1480,9 +1480,9 @@ case where the client has not processed messages.
 KeyPackages are another source of keying material that must be replaced,
 because using old KeyPackages is a threat to PCS. MLS defends against this
 problem by having KeyPackages expire, however long KeyPackage lifetime gives
-poor PCS guarantees.
+weaker PCS guarantees.
 
-> **RECOMMENDATION:** Use a short maximum lifetime for KeyPackages.
+> **RECOMMENDATION:** Minimize lifetime for KeyPackages.
 
 These recommendations will reduce the ability of idle compromised clients to
 decrypt a potentially long set of messages that might have followed the point of

--- a/draft-ietf-mls-architecture.md
+++ b/draft-ietf-mls-architecture.md
@@ -676,11 +676,6 @@ multiple times. Clients are responsible for providing new KeyPackages as
 necessary in order to minimize the chance that the "last resort" KeyPackage will
 be used.
 
-To provide post-compromise security for messages sent using the initial keying
-material, KeyPackages are intended to be rotated regularly, and expire using
-the `lifetime` field of the enclosed LeafNode, thereby ensuring old KeyPackages
-are not used to join a group.
-
 > **RECOMMENDATION:** Ensure that "last resort" KeyPackages don't get used by
 > provisioning enough standard KeyPackages.
 
@@ -690,8 +685,6 @@ are not used to join a group.
 
 > **RECOMMENDATION:** Ensure that the client for which a last resort KeyPackage
 > has been used is updating leaf keys as early as possible.
-
-> **RECOMMENDATION:** Enforce KeyPackage expiration using the `lifetime` field.
 
 Overall, it needs to be noted that key packages need to be updated when
 signature keys are changed.

--- a/draft-ietf-mls-architecture.md
+++ b/draft-ietf-mls-architecture.md
@@ -1477,6 +1477,13 @@ case where the client has not processed messages.
 > **RECOMMENDATION:** Mandate key updates from clients that are not otherwise
 > sending messages and evict clients which are idle for too long.
 
+KeyPackages are another source of keying material that must be replaced,
+because using old KeyPackages is a threat to PCS. MLS defends against this
+problem by having KeyPackages expire, however long KeyPackage lifetime gives
+poor PCS guarantees.
+
+> **RECOMMENDATION:** Use a short maximum lifetime for KeyPackages.
+
 These recommendations will reduce the ability of idle compromised clients to
 decrypt a potentially long set of messages that might have followed the point of
 the compromise.

--- a/draft-ietf-mls-architecture.md
+++ b/draft-ietf-mls-architecture.md
@@ -676,6 +676,11 @@ multiple times. Clients are responsible for providing new KeyPackages as
 necessary in order to minimize the chance that the "last resort" KeyPackage will
 be used.
 
+To provide post-compromise security for messages sent using the initial keying
+material, KeyPackages are intended to be rotated regularly, and expire using
+the `lifetime` field of the enclosed LeafNode, thereby ensuring old KeyPackages
+are not used to join a group.
+
 > **RECOMMENDATION:** Ensure that "last resort" KeyPackages don't get used by
 > provisioning enough standard KeyPackages.
 
@@ -685,6 +690,8 @@ be used.
 
 > **RECOMMENDATION:** Ensure that the client for which a last resort KeyPackage
 > has been used is updating leaf keys as early as possible.
+
+> **RECOMMENDATION:** Enforce KeyPackage expiration using the `lifetime` field.
 
 Overall, it needs to be noted that key packages need to be updated when
 signature keys are changed.
@@ -1818,8 +1825,8 @@ service matter, not via technology.
 
 Because the DS is responsible for providing the initial keying material to
 clients, it can provide stale keys. This does not inherently lead to compromise
-of the message stream, but does allow it to attack forward security to a limited
-extent. This threat can be mitigated by having initial keys expire.
+of the message stream, but does allow it to attack post-compromise security to
+a limited extent. This threat can be mitigated by having initial keys expire.
 
 Initial keying material (KeyPackages) using the `basic` Credential type is more
 vulnerable to replacement by a malicious or compromised DS, as there is no


### PR DESCRIPTION
This is an alternative to #274, which adds a paragraph about KeyPackage lifetime in the [Forward and Post-Compromise Security section](https://datatracker.ietf.org/doc/html/draft-ietf-mls-architecture#name-forward-and-post-compromise).

This paragraph inside was the initial intent of #274, however the text I wrote there was redundant with [RFC 9420](https://www.rfc-editor.org/rfc/rfc9420.html#section-16.6-5) (as noted by @Bren2010) and ended up being removed. I believe the paragraph in this pull-request is better, and answers my concerns expressed [here](https://github.com/mlswg/mls-architecture/pull/274#issuecomment-2689145681) and [here](https://mailarchive.ietf.org/arch/msg/mls/WZODZ3-f4INBUB5YBFpmADK1V2Y/).