### PR TITLE
Various minor consistency issues. Fixes #312

### DIFF
--- a/draft-ietf-mls-architecture.md
+++ b/draft-ietf-mls-architecture.md
@@ -260,7 +260,7 @@ While the recommendations of this document are not mandatory to follow in order
 to interoperate at the protocol level, they affect the overall security
 guarantees that are achieved by a messaging application. This is especially true
 in the case of active adversaries that are able to compromise clients, the
-delivery service, or the authentication service.
+Delivery Service (DS), or the Authentication Service (AS).
 
 --- middle
 
@@ -307,7 +307,7 @@ A _Proposal_ message proposes
 a change to be made in the next epoch, such as adding or removing a member.
 A _Commit_ message initiates a new epoch by instructing members of the group to
 implement a collection of proposals. Proposals and Commits are collectively
-called _Handshake messages_.
+called _handshake messages_.
 A _KeyPackage_ provides keys that can be used to add the client to a group,
 including its LeafNode, and _Signature Key_.
 A _Welcome_ message provides a new member to the group with the information to
@@ -316,7 +316,7 @@ initialize their state for the epoch in which they were added.
 Of course most (but not all) applications use MLS to send encrypted group messages.
 An _application message_ is an MLS message with an arbitrary application payload.
 
-Finally, a _PublicMessage_ contains an integrity-protected MLS Handshake message,
+Finally, a _PublicMessage_ contains an integrity-protected MLS handshake message,
 while a _PrivateMessage_ contains a confidential, integrity-protected Handshake
 or application message.
 
@@ -362,7 +362,7 @@ may even involve some action by users.  For example:
   existing PKI roles (e.g., Certification Authorities).
 
 It is important to note that the AS can be
-completely abstract in the case of a Service Provider which allows MLS
+completely abstract in the case of a service provider which allows MLS
 clients to generate, distribute, and validate credentials themselves.
 As with the AS, the DS can be completely abstract if
 users are able to distribute credentials and messages without relying
@@ -417,17 +417,17 @@ Initial Keying Material ----------------------------------->     |
 Get Bob Initial Keying Material --------------------------->     |
 <------------------------------- Bob Initial Keying Material     |
 Add Bob to Group ------------------------------------------>     | Step 3
-Welcome (Bob) --------------------------------------------->     |
+Welcome(Bob) ---------------------------------------------->     |
           <-------------------------------- Add Bob to Group     |
-          <----------------------------------- Welcome (Bob)     |
+          <------------------------------------ Welcome(Bob)     |
 
 Get Charlie Initial Keying Material ----------------------->     |
 <--------------------------- Charlie Initial Keying Material     |
 Add Charlie to Group -------------------------------------->     |
-Welcome (Charlie) ----------------------------------------->     | Step 4
+Welcome(Charlie) ------------------------------------------>     | Step 4
           <---------------------------- Add Charlie to Group     |
                      <----------------- Add Charlie to Group     |
-                     <-------------------- Welcome (Charlie)     |
+                     <--------------------- Welcome(Charlie)     |
 ~~~
 {: #fig-group-formation-example title="Group Formation Example"}
 
@@ -456,7 +456,7 @@ up his initial keying material. She then generates two messages:
 * A message to the entire group (which at this point is just her and Bob)
   that adds Bob to the group.
 
-* A _Welcome_ message just to Bob encrypted with his initial keying material that
+* A Welcome message just to Bob encrypted with his initial keying material that
   includes the secret keying information necessary to join the group.
 
 She sends both of these messages to the DS, which is responsible
@@ -474,7 +474,7 @@ up his initial keying material and then generates two messages:
 * A message to the entire group (consisting of her, Bob, and Charlie) adding
   Charlie to the group.
 
-* A _Welcome_ message just to Charlie encrypted with his initial keying material that
+* A Welcome message just to Charlie encrypted with his initial keying material that
   includes the secret keying information necessary to join the group.
 
 At the completion of this process, we have a group with Alice, Bob, and Charlie,
@@ -552,7 +552,7 @@ determine how to present this situation to users. For instance, it may render
 messages to and from a given user identically regardless of which client they
 are associated with, or it may choose to distinguish them.
 
-When a client is part of a Group, it is called a Member.  A group in MLS is
+When a client is part of a group, it is called a member.  A group in MLS is
 defined as the set of clients that have knowledge of the shared group secret
 established in the group key establishment phase.  Note that until a client has
 been added to the group and contributed to the group secret in a manner
@@ -745,7 +745,7 @@ DS might fall into:
 
 Strategies for sequencing messages in strongly and eventually consistent systems
 are described in the next two subsections. Most DSs will use the
-Strongly Consistent paradigm, but this remains a choice that can be handled in
+strongly consistent paradigm, but this remains a choice that can be handled in
 coordination with the client and advertised in the KeyPackages.
 
 However, note that a malicious DS could also reorder messages or
@@ -1002,7 +1002,7 @@ application could decide that a group administrator will be the only member to
 perform Add and Remove operations. On the other hand, in many settings such as
 open discussion forums, joining can be allowed for anyone.
 
-While MLS Application messages are always encrypted,
+While MLS application messages are always encrypted,
 MLS handshake messages can be sent either encrypted (in an MLS
 PrivateMessage) or unencrypted (in an MLS PublicMessage). Applications
 may be designed such that intermediaries need to see handshake
@@ -1369,7 +1369,7 @@ cryptographically binding it to the message.
 > **Recommendation:** Use the "Additional Authenticated Data" field of the
 > PrivateMessage instead of using other unauthenticated means of sending
 > metadata throughout the infrastructure. If the data should be kept private, the
-> infrastructure should use encrypted Application messages instead.
+> infrastructure should use encrypted application messages instead.
 
 ### Metadata Protection for Unencrypted Group Operations
 
@@ -1579,16 +1579,16 @@ the following compromise scenarios:
 
 ### Compromise of Symmetric Keying Material {#symmetric-key-compromise}
 
-As described above, each MLS epoch creates a new Group Secret.
+As described above, each MLS epoch creates a new group Secret.
 
-These group secrets are then used to create a per-sender Ratchet Secret, which
+These group secrets are then used to create a per-sender ratchet secret, which
 in turn is used to create a per-sender
 Authenticated Encryption with Associated Data (AEAD) {{!RFC5116}}
-key that is then used to encrypt MLS Plaintext messages.  Each time a message is
-sent, the Ratchet Secret is used to create a new Ratchet Secret and a new
+key that is then used to encrypt MLS plaintext messages.  Each time a message is
+sent, the ratchet secret is used to create a new ratchet secret and a new
 corresponding AEAD key.  Because of the properties of the key derivation
-function, it is not possible to compute a Ratchet Secret from its corresponding
-AEAD key or compute Ratchet Secret n-1 from Ratchet Secret n.
+function, it is not possible to compute a ratchet secret from its corresponding
+AEAD key or compute ratchet secret n-1 from ratchet secret n.
 
 Below, we consider the compromise of each of these pieces of keying material in
 turn, in ascending order of severity.  While this is a limited kind of
@@ -1598,22 +1598,22 @@ only part of the memory leaks to the adversary.
 #### Compromise of AEAD Keys
 
 In some circumstances, adversaries may have access to specific AEAD keys and
-nonces which protect an Application message or a Group Operation message. Compromise of
+nonces which protect an application message or a group Operation message. Compromise of
 these keys allows the attacker to decrypt the specific message encrypted with
-that key but no other; because the AEAD keys are derived from the Ratchet
-Secret, it cannot generate the next Ratchet Secret and hence not the next AEAD
+that key but no other; because the AEAD keys are derived from the ratchet
+secret, it cannot generate the next ratchet secret and hence not the next AEAD
 key.
 
-In the case of an Application message, an AEAD key compromise means that the
+In the case of an application message, an AEAD key compromise means that the
 encrypted application message will be leaked as well as the signature over that
 message. This means that the compromise has both confidentiality and privacy
 implications on the future AEAD encryptions of that chain.  In the case of a
-Group Operation message, only the privacy is affected, as the signature is
+group Operation message, only the privacy is affected, as the signature is
 revealed, because the secrets themselves are protected by Hybrid Public Key Encryption
 (HPKE).  Note
 that under that compromise scenario, authentication is not affected in either of
 these cases.  As every member of the group can compute the AEAD keys for all the
-chains (they have access to the Group Secrets) in order to send and receive
+chains (they have access to the group secrets) in order to send and receive
 messages, the authentication provided by the AEAD encryption layer of the common
 framing mechanism is weak. Successful decryption of an AEAD encrypted message
 only guarantees that some member of the group sent the message.
@@ -1625,10 +1625,10 @@ forms of symmetric key compromise described in {{symmetric-key-compromise}}.
 
 #### Compromise of Ratchet Secret Material
 
-When a Ratchet Secret is compromised, the adversary can compute both the current
+When a ratchet secret is compromised, the adversary can compute both the current
 AEAD keys for a given sender and any future keys for that sender in this
 epoch. Thus, it can decrypt current and future messages by the corresponding
-sender. However, because it does not have previous Ratchet Secrets, it cannot
+sender. However, because it does not have previous ratchet secrets, it cannot
 decrypt past messages as long as those secrets and keys have been deleted.
 
 Because of its forward secrecy guarantees, MLS will also retain secrecy of all
@@ -1641,14 +1641,14 @@ access any protected messages from future epochs.
 
 #### Compromise of the Group Secrets of a Single Group for One or More Group Epochs
 
-An adversary who gains access to a set of Group secrets -- as when a member of the
+An adversary who gains access to a set of group secrets -- as when a member of the
 group is compromised -- is significantly more powerful. In this section, we
 consider the case where the signature keys are not compromised. This can occur
 if the attacker has access to part of the memory containing the group secrets
 but not to the signature keys which might be stored in a secure enclave.
 
 In this scenario, the adversary gains the ability to compute any number of
-Ratchet Secrets for the epoch and their corresponding AEAD encryption keys and
+ratchet secrets for the epoch and their corresponding AEAD encryption keys and
 thus can encrypt and decrypt all messages for the compromised epochs.
 
 If the adversary is passive, it is expected from the PCS properties of the MLS
@@ -1813,7 +1813,7 @@ not be enough to provide strong privacy or anonymity properties.
 In the case where private data or metadata has to be persisted on the servers
 for functionality (mappings between identities and push tokens, group
 metadata, etc.), it should be stored encrypted at rest and only decrypted upon need
-during the execution. Honest Service Providers can rely on such "encryption at
+during the execution. Honest service provideros can rely on such "encryption at
 rest" mechanisms to be able to prevent access to the data when not using it.
 
 > **Recommendation:** Store cryptographic material used for server-side
@@ -1846,20 +1846,20 @@ clients, it can provide stale keys. This does not inherently lead to compromise
 of the message stream, but does allow the DS to attack post-compromise security to
 a limited extent. This threat can be mitigated by having initial keys expire.
 
-Initial keying material (KeyPackages) using the `basic` Credential type is more
+Initial keying material (KeyPackages) using the `basic` credential type is more
 vulnerable to replacement by a malicious or compromised DS, as there is no
 built-in cryptographic binding between the identity and the public key of the
 client.
 
-> **Recommendation:** Prefer a Credential type in KeyPackages which includes a
+> **Recommendation:** Prefer a credential type in KeyPackages which includes a
 > strong cryptographic binding between the identity and its key (for example, the
-> `x509` Credential type). When using the `basic` Credential type, take extra
+> `x509` credential type). When using the `basic` credential type, take extra
 > care to verify the identity (typically out of band).
 
 
 #### Privacy of Delivery and Push Notifications
 
-Push-tokens provide an important mechanism that is often ignored from
+push tokens provide an important mechanism that is often ignored from
 the standpoint of privacy considerations. In many modern messaging
 architectures, applications are using push notification mechanisms
 typically provided by OS vendors. This is to make sure that when
@@ -1871,7 +1871,7 @@ round trip with the DS.
 
 To "push" this information to the device, the service provider and the OS
 infrastructures use unique per-device, per-application identifiers called
-push-tokens. This means that the push notification provider and the service
+push tokens. This means that the push notification provider and the service
 provider have information on which devices receive information and at which
 point in time. Alternatively, non-mobile applications could use a WebSocket or
 persistent connection for notifications directly from the DS.
@@ -1888,9 +1888,9 @@ is not acceptable to create artificial delays for message retrieval.
 > delay notifications randomly across recipient devices using a mixnet or other
 > techniques.
 
-Note that with a legal request to ask the service provider for the push-token
+Note that with a legal request to ask the service provider for the push token
 associated with an identifier, it is easy to correlate the token with a second
-request to the company operating the push-notification system to get information
+request to the company operating the push notification system to get information
 about the device, which is often linked with a real identity via a cloud
 account, a credit card, or other information.
 
@@ -1932,33 +1932,33 @@ attacker who has compromised the AS to silently impersonate the client.
 
 #### Authentication Compromise: Ghost Users and Impersonation
 
-One important property of MLS is that all Members know which other members are
-in the group at all times. If all Members of the group and the Authentication
+One important property of MLS is that all members know which other members are
+in the group at all times. If all members of the group and the Authentication
 Service are honest, no parties other than the members of the current group can
 read and write messages protected by the protocol for that Group.
 
 This guarantee applies to the cryptographic identities of the members.
 Details about how to verify the identity of a client depend on the MLS
-Credential type used. For example, cryptographic verification of credentials can
+credential type used. For example, cryptographic verification of credentials can
 be largely performed autonomously (e.g., without user interaction) by the
-clients themselves for the `x509` Credential type.
+clients themselves for the `x509` credential type.
 
-In contrast, when MLS clients use the `basic` Credential type, some other
+In contrast, when MLS clients use the `basic` credential type, some other
 mechanism must be used to verify identities. For instance, the Authentication
 Service could operate some sort of directory server to provide keys, or users
 could verify keys via an out-of-band mechanism.
 
-> **Recommendation:** Select the MLS Credential type with the strongest security
+> **Recommendation:** Select the MLS credential type with the strongest security
 > which is supported by all target members of an MLS group.
 
-> **Recommendation:** Do not use the same signature keypair across
+> **Recommendation:** Do not use the same signature key pair across
 > groups. Update all keys for all groups on a regular basis. Do not preserve
 > keys in different groups when suspecting a compromise.
 
 If the AS is compromised, it could validate a signature
-keypair (or generate a new one) for an attacker. The attacker could then use this keypair to join a
+key pair (or generate a new one) for an attacker. The attacker could then use this key pair to join a
 group as if it were another of the user's clients.  Because a user can have many
-MLS clients running the MLS protocol, it possibly has many signature keypairs
+MLS clients running the MLS protocol, it possibly has many signature key pairs
 for multiple devices. These attacks could be very difficult to detect,
 especially in large groups where the UI might not reflect all the changes back
 to the users. If the application participates in a key transparency mechanism in
@@ -2052,7 +2052,7 @@ whom replay is an important risk should apply mitigations at the application lay
 discussed below.
 
 In addition to the risks discussed in {{symmetric-key-compromise}}, an attacker
-with access to the Ratchet Secrets for an endpoint can replay PrivateMessage
+with access to the ratchet secrets for an endpoint can replay PrivateMessage
 objects sent by other members of the group by taking the signed content of the
 message and re-encrypting it with a new generation of the original sender's
 ratchet.  If the other members of the group interpret a message with a new

--- a/draft-ietf-mls-architecture.md
+++ b/draft-ietf-mls-architecture.md
@@ -416,17 +416,17 @@ Initial Keying Material ----------------------------------->     |
 
 Get Bob Initial Keying Material --------------------------->     |
 <------------------------------- Bob Initial Keying Material     |
-Add Bob to Group ------------------------------------------>     | Step 3
+Add Bob to group ------------------------------------------>     | Step 3
 Welcome(Bob) ---------------------------------------------->     |
-          <-------------------------------- Add Bob to Group     |
+          <-------------------------------- Add Bob to group     |
           <------------------------------------ Welcome(Bob)     |
 
 Get Charlie Initial Keying Material ----------------------->     |
 <--------------------------- Charlie Initial Keying Material     |
-Add Charlie to Group -------------------------------------->     |
+Add Charlie to group -------------------------------------->     |
 Welcome(Charlie) ------------------------------------------>     | Step 4
-          <---------------------------- Add Charlie to Group     |
-                     <----------------- Add Charlie to Group     |
+          <---------------------------- Add Charlie to group     |
+                     <----------------- Add Charlie to group     |
                      <--------------------- Welcome(Charlie)     |
 ~~~
 {: #fig-group-formation-example title="Group Formation Example"}

--- a/draft-ietf-mls-architecture.md
+++ b/draft-ietf-mls-architecture.md
@@ -1579,7 +1579,7 @@ the following compromise scenarios:
 
 ### Compromise of Symmetric Keying Material {#symmetric-key-compromise}
 
-As described above, each MLS epoch creates a new group Secret.
+As described above, each MLS epoch creates a new group secret.
 
 These group secrets are then used to create a per-sender ratchet secret, which
 in turn is used to create a per-sender
@@ -1598,7 +1598,7 @@ only part of the memory leaks to the adversary.
 #### Compromise of AEAD Keys
 
 In some circumstances, adversaries may have access to specific AEAD keys and
-nonces which protect an application message or a group Operation message. Compromise of
+nonces which protect an application message or a group operation message. Compromise of
 these keys allows the attacker to decrypt the specific message encrypted with
 that key but no other; because the AEAD keys are derived from the ratchet
 secret, it cannot generate the next ratchet secret and hence not the next AEAD
@@ -1608,7 +1608,7 @@ In the case of an application message, an AEAD key compromise means that the
 encrypted application message will be leaked as well as the signature over that
 message. This means that the compromise has both confidentiality and privacy
 implications on the future AEAD encryptions of that chain.  In the case of a
-group Operation message, only the privacy is affected, as the signature is
+group operation message, only the privacy is affected, as the signature is
 revealed, because the secrets themselves are protected by Hybrid Public Key Encryption
 (HPKE).  Note
 that under that compromise scenario, authentication is not affected in either of

--- a/draft-ietf-mls-architecture.md
+++ b/draft-ietf-mls-architecture.md
@@ -1813,7 +1813,7 @@ not be enough to provide strong privacy or anonymity properties.
 In the case where private data or metadata has to be persisted on the servers
 for functionality (mappings between identities and push tokens, group
 metadata, etc.), it should be stored encrypted at rest and only decrypted upon need
-during the execution. Honest service provideros can rely on such "encryption at
+during the execution. Honest service providers can rely on such "encryption at
 rest" mechanisms to be able to prevent access to the data when not using it.
 
 > **Recommendation:** Store cryptographic material used for server-side
@@ -1935,7 +1935,7 @@ attacker who has compromised the AS to silently impersonate the client.
 One important property of MLS is that all members know which other members are
 in the group at all times. If all members of the group and the Authentication
 Service are honest, no parties other than the members of the current group can
-read and write messages protected by the protocol for that Group.
+read and write messages protected by the protocol for that group.
 
 This guarantee applies to the cryptographic identities of the members.
 Details about how to verify the identity of a client depend on the MLS

--- a/rfc9750-draft.xml
+++ b/rfc9750-draft.xml
@@ -2318,23 +2318,6 @@ authentication and cross-group healing guarantees provided by MLS.</t>
           </front>
           <refcontent>Cryptology ePrint Archive</refcontent>
         </reference>
-
-<!-- [rfced] [BCK21]:  We updated this listing to use the title
-found on the provided URL, as we found "Cryptographic Security of the
-MLS RFC, Draft 11" on <https://eprint.iacr.org/2021/137> but again
-found "Security Analysis of the MLS Key Distribution" when we clicked
-"PDF" under "Available format(s)".  Please let us know any concerns.
-
-Original:
- [BCK21]    Brzuska, C., Cornelissen, E., and K. Kohbrok,
-            "Cryptographic Security of the MLS RFC, Draft 11", 2021,
-            <https://eprint.iacr.org/2021/137.pdf>.
-
-Currently:
- [BCK21]    Brzuska, C., Cornelissen, E., and K. Kohbrok, "Security
-            Analysis of the MLS Key Distribution", Cryptology ePrint
-            Archive, 2021, <https://eprint.iacr.org/2021/137.pdf>. -->
-
         <reference anchor="CHK21" target="https://www.usenix.org/system/files/sec21-cremers.pdf">
           <front>
             <title>The Complexities of Healing in Secure Group Messaging: Why Cross-Group Effects Matter</title>

--- a/rfc9750-draft.xml
+++ b/rfc9750-draft.xml
@@ -68,7 +68,7 @@ MLS and are instead left to the application.</t>
 to interoperate at the protocol level, they affect the overall security
 guarantees that are achieved by a messaging application. This is especially true
 in the case of active adversaries that are able to compromise clients, the
-delivery service, or the authentication service.</t>
+Delivery Service (DS), or the Authentication Service (AS).</t>
     </abstract>
   </front>
   <middle>
@@ -113,14 +113,14 @@ A <em>Proposal</em> message proposes
 a change to be made in the next epoch, such as adding or removing a member.
 A <em>Commit</em> message initiates a new epoch by instructing members of the group to
 implement a collection of proposals. Proposals and Commits are collectively
-called <em>Handshake messages</em>.&nbsp;
+called <em>handshake messages</em>.
 A <em>KeyPackage</em> provides keys that can be used to add the client to a group,
-including its LeafNode, and <em>Signature Key</em>.&nbsp;
+including its LeafNode, and <em>Signature Key</em>.
 A <em>Welcome</em> message provides a new member to the group with the information to
 initialize their state for the epoch in which they were added.</t>
         <t>Of course most (but not all) applications use MLS to send encrypted group messages.
 An <em>application message</em> is an MLS message with an arbitrary application payload.</t>
-        <t>Finally, a <em>PublicMessage</em> contains an integrity-protected MLS Handshake message,
+        <t>Finally, a <em>PublicMessage</em> contains an integrity-protected MLS handshake message,
 while a <em>PrivateMessage</em> contains a confidential, integrity-protected Handshake
 or application message.</t>
         <t>For a more detailed explanation of these terms, please consult the MLS protocol
@@ -173,7 +173,7 @@ existing PKI roles (e.g., Certification Authorities).</t>
           </li>
         </ul>
         <t>It is important to note that the AS can be
-completely abstract in the case of a Service Provider which allows MLS
+completely abstract in the case of a service provider which allows MLS
 clients to generate, distribute, and validate credentials themselves.
 As with the AS, the DS can be completely abstract if
 users are able to distribute credentials and messages without relying
@@ -569,7 +569,7 @@ client will have its own cryptographic state, and it is up to the application to
 determine how to present this situation to users. For instance, it may render
 messages to and from a given user identically regardless of which client they
 are associated with, or it may choose to distinguish them.</t>
-        <t>When a client is part of a Group, it is called a Member.  A group in MLS is
+        <t>When a client is part of a group, it is called a member.  A group in MLS is
 defined as the set of clients that have knowledge of the shared group secret
 established in the group key establishment phase.  Note that until a client has
 been added to the group and contributed to the group secret in a manner
@@ -770,7 +770,7 @@ different users.</t>
         </ul>
         <t>Strategies for sequencing messages in strongly and eventually consistent systems
 are described in the next two subsections. Most DSs will use the
-Strongly Consistent paradigm, but this remains a choice that can be handled in
+strongly consistent paradigm, but this remains a choice that can be handled in
 coordination with the client and advertised in the KeyPackages.</t>
         <t>However, note that a malicious DS could also reorder messages or
 provide an inconsistent view to different users.  The "generation" counter in
@@ -1011,7 +1011,7 @@ application could decide that a group administrator will be the only member to
 perform Add and Remove operations. On the other hand, in many settings such as
 open discussion forums, joining can be allowed for anyone.
 </t>
-        <t>While MLS Application messages are always encrypted,
+        <t>While MLS application messages are always encrypted,
 MLS handshake messages can be sent either encrypted (in an MLS
 PrivateMessage) or unencrypted (in an MLS PublicMessage). Applications
 may be designed such that intermediaries need to see handshake
@@ -1441,7 +1441,7 @@ cryptographically binding it to the message.</t>
               <t indent="3"><strong>Recommendation:</strong> Use the "Additional Authenticated Data" field of the
 PrivateMessage instead of using other unauthenticated means of sending
 metadata throughout the infrastructure. If the data should be kept private, the
-infrastructure should use encrypted Application messages instead.</t>
+infrastructure should use encrypted application messages instead.</t>
         </section>
         <section anchor="metadata-protection-for-unencrypted-group-operations">
           <name>Metadata Protection for Unencrypted Group Operations</name>
@@ -1636,15 +1636,15 @@ compromise).</t>
         </ul>
         <section anchor="symmetric-key-compromise">
           <name>Compromise of Symmetric Keying Material</name>
-          <t>As described above, each MLS epoch creates a new Group Secret.</t>
-          <t>These group secrets are then used to create a per-sender Ratchet Secret, which
+          <t>As described above, each MLS epoch creates a new group secret.</t>
+          <t>These group secrets are then used to create a per-sender ratchet secret, which
 in turn is used to create a per-sender Authenticated Encryption with
    Associated Data (AEAD) <xref target="RFC5116"/> key
-that is then used to encrypt MLS Plaintext messages.  Each time a message is
-sent, the Ratchet Secret is used to create a new Ratchet Secret and a new
+that is then used to encrypt MLS plaintext messages.  Each time a message is
+sent, the ratchet secret is used to create a new ratchet secret and a new
 corresponding AEAD key.  Because of the properties of the key derivation
-function, it is not possible to compute a Ratchet Secret from its corresponding
-AEAD key or compute Ratchet Secret n-1 from Ratchet Secret n.
+function, it is not possible to compute a ratchet secret from its corresponding
+AEAD key or compute ratchet secret n-1 from ratchet secret n.
 </t>
           <t>Below, we consider the compromise of each of these pieces of keying material in
 turn, in ascending order of severity.  While this is a limited kind of
@@ -1653,20 +1653,20 @@ only part of the memory leaks to the adversary.</t>
           <section anchor="compromise-of-aead-keys">
             <name>Compromise of AEAD Keys</name>
             <t>In some circumstances, adversaries may have access to specific AEAD keys and
-nonces which protect an Application message or a Group Operation message. Compromise of
+nonces which protect an application message or a group operation message. Compromise of
 these keys allows the attacker to decrypt the specific message encrypted with
-that key but no other; because the AEAD keys are derived from the Ratchet
-Secret, it cannot generate the next Ratchet Secret and hence not the next AEAD
+that key but no other; because the AEAD keys are derived from the ratchet
+secret, it cannot generate the next ratchet secret and hence not the next AEAD
 key.</t>
-            <t>In the case of an Application message, an AEAD key compromise means that the
+            <t>In the case of an application message, an AEAD key compromise means that the
 encrypted application message will be leaked as well as the signature over that
 message. This means that the compromise has both confidentiality and privacy
 implications on the future AEAD encryptions of that chain.  In the case of a
-Group Operation message, only the privacy is affected, as the signature is
+group operation message, only the privacy is affected, as the signature is
 revealed, because the secrets themselves are protected by Hybrid Public Key Encryption (HPKE).  Note
 that under that compromise scenario, authentication is not affected in either of
 these cases.  As every member of the group can compute the AEAD keys for all the
-chains (they have access to the Group Secrets) in order to send and receive
+chains (they have access to the group secrets) in order to send and receive
 messages, the authentication provided by the AEAD encryption layer of the common
 framing mechanism is weak. Successful decryption of an AEAD encrypted message
 only guarantees that some member of the group sent the message.
@@ -1679,10 +1679,10 @@ forms of symmetric key compromise described in <xref target="symmetric-key-compr
           </section>
           <section anchor="compromise-of-ratchet-secret-material">
             <name>Compromise of Ratchet Secret Material</name>
-            <t>When a Ratchet Secret is compromised, the adversary can compute both the current
+            <t>When a ratchet secret is compromised, the adversary can compute both the current
 AEAD keys for a given sender and any future keys for that sender in this
 epoch. Thus, it can decrypt current and future messages by the corresponding
-sender. However, because it does not have previous Ratchet Secrets, it cannot
+sender. However, because it does not have previous ratchet secrets, it cannot
 decrypt past messages as long as those secrets and keys have been deleted.
 </t>
             <t>Because of its forward secrecy guarantees, MLS will also retain secrecy of all
@@ -1695,13 +1695,13 @@ access any protected messages from future epochs.</t>
           </section>
           <section anchor="compromise-of-the-group-secrets-of-a-single-group-for-one-or-more-group-epochs">
             <name>Compromise of the Group Secrets of a Single Group for One or More Group Epochs</name>
-            <t>An adversary who gains access to a set of Group secrets -- as when a member of the
+            <t>An adversary who gains access to a set of group secrets -- as when a member of the
 group is compromised -- is significantly more powerful. In this section, we
 consider the case where the signature keys are not compromised. This can occur
 if the attacker has access to part of the memory containing the group secrets
 but not to the signature keys which might be stored in a secure enclave.</t>
             <t>In this scenario, the adversary gains the ability to compute any number of
-Ratchet Secrets for the epoch and their corresponding AEAD encryption keys and
+ratchet secrets for the epoch and their corresponding AEAD encryption keys and
 thus can encrypt and decrypt all messages for the compromised epochs.</t>
             <t>If the adversary is passive, it is expected from the PCS properties of the MLS
 protocol that as soon as the compromised party remediates the compromise and
@@ -1852,7 +1852,7 @@ not be enough to provide strong privacy or anonymity properties.</t>
             <t>In the case where private data or metadata has to be persisted on the servers
 for functionality (mappings between identities and push tokens, group
 metadata, etc.), it should be stored encrypted at rest and only decrypted upon need
-during the execution. Honest Service Providers can rely on such "encryption at
+during the execution. Honest service providers can rely on such "encryption at
 rest" mechanisms to be able to prevent access to the data when not using it.</t>
                 <t indent="3"><strong>Recommendation:</strong> Store cryptographic material used for server-side
 decryption of sensitive metadata on the clients and only send it when needed.
@@ -1881,17 +1881,17 @@ service matter, not via technology.</t>
 clients, it can provide stale keys. This does not inherently lead to compromise
 of the message stream, but does allow the DS to attack post-compromise security to a limited
 extent. This threat can be mitigated by having initial keys expire.</t>
-          <t>Initial keying material (KeyPackages) using the <tt>basic</tt> Credential type is more
+          <t>Initial keying material (KeyPackages) using the <tt>basic</tt> credential type is more
 vulnerable to replacement by a malicious or compromised DS, as there is no
 built-in cryptographic binding between the identity and the public key of the
 client.</t>
-              <t indent="3"><strong>Recommendation:</strong> Prefer a Credential type in KeyPackages which includes a
+              <t indent="3"><strong>Recommendation:</strong> Prefer a credential type in KeyPackages which includes a
 strong cryptographic binding between the identity and its key (for example, the
-<tt>x509</tt> Credential type). When using the <tt>basic</tt> Credential type, take extra
+<tt>x509</tt> credential type). When using the <tt>basic</tt> credential type, take extra
 care to verify the identity (typically out of band).</t>
           <section anchor="privacy-of-delivery-and-push-notifications">
             <name>Privacy of Delivery and Push Notifications</name>
-            <t>Push-tokens provide an important mechanism that is often ignored from the standpoint of privacy considerations. In many modern messaging architectures, applications are using
+            <t>push tokens provide an important mechanism that is often ignored from the standpoint of privacy considerations. In many modern messaging architectures, applications are using
 push notification mechanisms typically provided by OS vendors. This is to make
 sure that when messages are available at the DS (or via other
 mechanisms if the DS is not a central server), the recipient application on a
@@ -1899,7 +1899,7 @@ device knows about it. Sometimes the push notification can contain the
 application message itself, which saves a round trip with the DS.</t>
             <t>To "push" this information to the device, the service provider and the OS
 infrastructures use unique per-device, per-application identifiers called
-push-tokens. This means that the push notification provider and the service
+push tokens. This means that the push notification provider and the service
 provider have information on which devices receive information and at which
 point in time. Alternatively, non-mobile applications could use a WebSocket or
 persistent connection for notifications directly from the DS.</t>
@@ -1912,9 +1912,9 @@ is not acceptable to create artificial delays for message retrieval.</t>
                 <t indent="3"><strong>Recommendation:</strong> If real-time notifications are not necessary, one can
 delay notifications randomly across recipient devices using a mixnet or other
 techniques.</t>
-            <t>Note that with a legal request to ask the service provider for the push-token
+            <t>Note that with a legal request to ask the service provider for the push token
 associated with an identifier, it is easy to correlate the token with a second
-request to the company operating the push-notification system to get information
+request to the company operating the push notification system to get information
 about the device, which is often linked with a real identity via a cloud
 account, a credit card, or other information.</t>
                 <t indent="3"><strong>Recommendation:</strong> If stronger privacy guarantees are needed with regard to
@@ -1957,28 +1957,28 @@ their credential. This is a dangerous practice because it allows the AS or an
 attacker who has compromised the AS to silently impersonate the client.</t>
           <section anchor="authentication-compromise-ghost-users-and-impersonations">
             <name>Authentication Compromise: Ghost Users and Impersonation</name>
-            <t>One important property of MLS is that all Members know which other members are
-in the group at all times. If all Members of the group and the Authentication
+            <t>One important property of MLS is that all members know which other members are
+in the group at all times. If all members of the group and the Authentication
 Service are honest, no parties other than the members of the current group can
-read and write messages protected by the protocol for that Group.</t>
+read and write messages protected by the protocol for that group.</t>
             <t>This guarantee applies to the cryptographic identities of the members.
 Details about how to verify the identity of a client depend on the MLS
-Credential type used. For example, cryptographic verification of credentials can
+credential type used. For example, cryptographic verification of credentials can
 be largely performed autonomously (e.g., without user interaction) by the
-clients themselves for the <tt>x509</tt> Credential type.</t>
-            <t>In contrast, when MLS clients use the <tt>basic</tt> Credential type, some other
+clients themselves for the <tt>x509</tt> credential type.</t>
+            <t>In contrast, when MLS clients use the <tt>basic</tt> credential type, some other
 mechanism must be used to verify identities. For instance, the Authentication
 Service could operate some sort of directory server to provide keys, or users
 could verify keys via an out-of-band mechanism.</t>
-                <t indent="3"><strong>Recommendation:</strong> Select the MLS Credential type with the strongest security
+                <t indent="3"><strong>Recommendation:</strong> Select the MLS credential type with the strongest security
 which is supported by all target members of an MLS group.</t>
-                <t indent="3"><strong>Recommendation:</strong> Do not use the same signature keypair across
+                <t indent="3"><strong>Recommendation:</strong> Do not use the same signature key pair across
 groups. Update all keys for all groups on a regular basis. Do not preserve
 keys in different groups when suspecting a compromise.</t>
             <t>If the AS is compromised, it could validate a signature
-keypair (or generate a new one) for an attacker. The attacker could then use this keypair to join a
+key pair (or generate a new one) for an attacker. The attacker could then use this key pair to join a
 group as if it were another of the user's clients.  Because a user can have many
-MLS clients running the MLS protocol, it possibly has many signature keypairs
+MLS clients running the MLS protocol, it possibly has many signature key pairs
 for multiple devices. These attacks could be very difficult to detect,
 especially in large groups where the UI might not reflect all the changes back
 to the users. If the application participates in a key transparency mechanism in
@@ -2061,7 +2061,7 @@ within the same epoch that the message was originally sent. Applications for
 whom replay is an important risk should apply mitigations at the application layer, as
 discussed below.</t>
       <t>In addition to the risks discussed in <xref target="symmetric-key-compromise"/>, an attacker
-with access to the Ratchet Secrets for an endpoint can replay PrivateMessage
+with access to the ratchet secrets for an endpoint can replay PrivateMessage
 objects sent by other members of the group by taking the signed content of the
 message and re-encrypting it with a new generation of the original sender's
 ratchet.  If the other members of the group interpret a message with a new
@@ -2574,7 +2574,7 @@ marked them with asterisks ("*").
    key transparency (2 instances) (e.g., "Key Transparency [KT]",
    "key transparency mechanism")
 
- * keypair (4 instances) / key pair (5 instances)
+ * key pair (4 instances) / key pair (5 instances)
      (RFC 9420 uses "key pair".)
 
  * Member (3 instances) / member (>50 instances) (used generally)

--- a/rfc9750-draft.xml
+++ b/rfc9750-draft.xml
@@ -465,7 +465,7 @@ up his initial keying material. She then generates two messages:</t>
 that adds Bob to the group.</t>
           </li>
           <li>
-            <t>A <em>Welcome</em> message just to Bob encrypted with his initial keying material that
+            <t>A Welcome message just to Bob encrypted with his initial keying material that
 includes the secret keying information necessary to join the group.</t>
           </li>
 	</ul>
@@ -486,7 +486,7 @@ up his initial keying material and then generates two messages:</t>
 Charlie to the group.</t>
           </li>
           <li>
-            <t>A <em>Welcome</em> message just to Charlie encrypted with his initial keying material that
+            <t>A Welcome message just to Charlie encrypted with his initial keying material that
 includes the secret keying information necessary to join the group.</t>
           </li>
 	</ul>

--- a/rfc9750-draft.xml
+++ b/rfc9750-draft.xml
@@ -277,7 +277,7 @@ group consisting of Alice, Bob, and Charlie, with Alice
       <figure anchor="fig-group-formation-example">
         <name>Group Formation Example</name>
         <artset>
-          <artwork type="svg"><svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="464" width="592" viewBox="0 0 592 464" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
+          <artwork type="svg"><svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="464" width="592" viewBox="0 0 592 464" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px">
               <path d="M 528,64 L 528,144" fill="none" stroke="black"/>
               <path d="M 528,176 L 528,208" fill="none" stroke="black"/>
               <path d="M 528,240 L 528,320" fill="none" stroke="black"/>
@@ -294,38 +294,38 @@ group consisting of Alice, Bob, and Charlie, with Alice
               <path d="M 264,240 L 480,240" fill="none" stroke="black"/>
               <path d="M 8,256 L 256,256" fill="none" stroke="black"/>
               <path d="M 144,272 L 480,272" fill="none" stroke="black"/>
-              <path d="M 104,288 L 480,288" fill="none" stroke="black"/>
+              <path d="M 112,288 L 480,288" fill="none" stroke="black"/>
               <path d="M 88,304 L 344,304" fill="none" stroke="black"/>
-              <path d="M 88,320 L 368,320" fill="none" stroke="black"/>
+              <path d="M 88,320 L 376,320" fill="none" stroke="black"/>
               <path d="M 296,352 L 480,352" fill="none" stroke="black"/>
               <path d="M 8,368 L 224,368" fill="none" stroke="black"/>
               <path d="M 176,384 L 480,384" fill="none" stroke="black"/>
-              <path d="M 152,400 L 480,400" fill="none" stroke="black"/>
+              <path d="M 144,400 L 480,400" fill="none" stroke="black"/>
               <path d="M 88,416 L 312,416" fill="none" stroke="black"/>
               <path d="M 176,432 L 312,432" fill="none" stroke="black"/>
-              <path d="M 176,448 L 336,448" fill="none" stroke="black"/>
-              <polygon class="arrowhead" points="488,400 476,394.4 476,405.6" fill="black" transform="rotate(0,480,400)"/>
-              <polygon class="arrowhead" points="488,384 476,378.4 476,389.6" fill="black" transform="rotate(0,480,384)"/>
-              <polygon class="arrowhead" points="488,352 476,346.4 476,357.6" fill="black" transform="rotate(0,480,352)"/>
-              <polygon class="arrowhead" points="488,288 476,282.4 476,293.6" fill="black" transform="rotate(0,480,288)"/>
-              <polygon class="arrowhead" points="488,272 476,266.4 476,277.6" fill="black" transform="rotate(0,480,272)"/>
-              <polygon class="arrowhead" points="488,240 476,234.4 476,245.6" fill="black" transform="rotate(0,480,240)"/>
-              <polygon class="arrowhead" points="488,208 476,202.4 476,213.6" fill="black" transform="rotate(0,480,208)"/>
-              <polygon class="arrowhead" points="488,192 476,186.4 476,197.6" fill="black" transform="rotate(0,480,192)"/>
-              <polygon class="arrowhead" points="488,176 476,170.4 476,181.6" fill="black" transform="rotate(0,480,176)"/>
-              <polygon class="arrowhead" points="400,128 388,122.4 388,133.6" fill="black" transform="rotate(0,392,128)"/>
-              <polygon class="arrowhead" points="400,96 388,90.4 388,101.6" fill="black" transform="rotate(0,392,96)"/>
-              <polygon class="arrowhead" points="400,64 388,58.4 388,69.6" fill="black" transform="rotate(0,392,64)"/>
-              <polygon class="arrowhead" points="184,448 172,442.4 172,453.6" fill="black" transform="rotate(180,176,448)"/>
-              <polygon class="arrowhead" points="184,432 172,426.4 172,437.6" fill="black" transform="rotate(180,176,432)"/>
-              <polygon class="arrowhead" points="176,144 164,138.4 164,149.6" fill="black" transform="rotate(180,168,144)"/>
-              <polygon class="arrowhead" points="96,416 84,410.4 84,421.6" fill="black" transform="rotate(180,88,416)"/>
-              <polygon class="arrowhead" points="96,320 84,314.4 84,325.6" fill="black" transform="rotate(180,88,320)"/>
-              <polygon class="arrowhead" points="96,304 84,298.4 84,309.6" fill="black" transform="rotate(180,88,304)"/>
-              <polygon class="arrowhead" points="96,112 84,106.4 84,117.6" fill="black" transform="rotate(180,88,112)"/>
-              <polygon class="arrowhead" points="16,368 4,362.4 4,373.6" fill="black" transform="rotate(180,8,368)"/>
-              <polygon class="arrowhead" points="16,256 4,250.4 4,261.6" fill="black" transform="rotate(180,8,256)"/>
-              <polygon class="arrowhead" points="16,80 4,74.4 4,85.6" fill="black" transform="rotate(180,8,80)"/>
+              <path d="M 176,448 L 344,448" fill="none" stroke="black"/>
+              <polygon class="arrowhead" points="488,400 476,394.4 476,405.6 " fill="black" transform="rotate(0,480,400)"/>
+              <polygon class="arrowhead" points="488,384 476,378.4 476,389.6 " fill="black" transform="rotate(0,480,384)"/>
+              <polygon class="arrowhead" points="488,352 476,346.4 476,357.6 " fill="black" transform="rotate(0,480,352)"/>
+              <polygon class="arrowhead" points="488,288 476,282.4 476,293.6 " fill="black" transform="rotate(0,480,288)"/>
+              <polygon class="arrowhead" points="488,272 476,266.4 476,277.6 " fill="black" transform="rotate(0,480,272)"/>
+              <polygon class="arrowhead" points="488,240 476,234.4 476,245.6 " fill="black" transform="rotate(0,480,240)"/>
+              <polygon class="arrowhead" points="488,208 476,202.4 476,213.6 " fill="black" transform="rotate(0,480,208)"/>
+              <polygon class="arrowhead" points="488,192 476,186.4 476,197.6 " fill="black" transform="rotate(0,480,192)"/>
+              <polygon class="arrowhead" points="488,176 476,170.4 476,181.6 " fill="black" transform="rotate(0,480,176)"/>
+              <polygon class="arrowhead" points="400,128 388,122.4 388,133.6 " fill="black" transform="rotate(0,392,128)"/>
+              <polygon class="arrowhead" points="400,96 388,90.4 388,101.6 " fill="black" transform="rotate(0,392,96)"/>
+              <polygon class="arrowhead" points="400,64 388,58.4 388,69.6 " fill="black" transform="rotate(0,392,64)"/>
+              <polygon class="arrowhead" points="184,448 172,442.4 172,453.6 " fill="black" transform="rotate(180,176,448)"/>
+              <polygon class="arrowhead" points="184,432 172,426.4 172,437.6 " fill="black" transform="rotate(180,176,432)"/>
+              <polygon class="arrowhead" points="176,144 164,138.4 164,149.6 " fill="black" transform="rotate(180,168,144)"/>
+              <polygon class="arrowhead" points="96,416 84,410.4 84,421.6 " fill="black" transform="rotate(180,88,416)"/>
+              <polygon class="arrowhead" points="96,320 84,314.4 84,325.6 " fill="black" transform="rotate(180,88,320)"/>
+              <polygon class="arrowhead" points="96,304 84,298.4 84,309.6 " fill="black" transform="rotate(180,88,304)"/>
+              <polygon class="arrowhead" points="96,112 84,106.4 84,117.6 " fill="black" transform="rotate(180,88,112)"/>
+              <polygon class="arrowhead" points="16,368 4,362.4 4,373.6 " fill="black" transform="rotate(180,8,368)"/>
+              <polygon class="arrowhead" points="16,256 4,250.4 4,261.6 " fill="black" transform="rotate(180,8,256)"/>
+              <polygon class="arrowhead" points="16,80 4,74.4 4,85.6 " fill="black" transform="rotate(180,8,80)"/>
               <g class="text">
                 <text x="24" y="36">Alice</text>
                 <text x="96" y="36">Bob</text>
@@ -366,17 +366,15 @@ group consisting of Alice, Bob, and Charlie, with Alice
                 <text x="16" y="276">Add</text>
                 <text x="48" y="276">Bob</text>
                 <text x="76" y="276">to</text>
-                <text x="112" y="276">Group</text>
+                <text x="112" y="276">group</text>
                 <text x="556" y="276">Step</text>
                 <text x="584" y="276">3</text>
-                <text x="32" y="292">Welcome</text>
-                <text x="84" y="292">(Bob)</text>
+                <text x="52" y="292">Welcome(Bob)</text>
                 <text x="368" y="308">Add</text>
                 <text x="400" y="308">Bob</text>
                 <text x="428" y="308">to</text>
-                <text x="464" y="308">Group</text>
-                <text x="408" y="324">Welcome</text>
-                <text x="464" y="324">(Bob)</text>
+                <text x="464" y="308">group</text>
+                <text x="436" y="324">Welcome(Bob)</text>
                 <text x="16" y="356">Get</text>
                 <text x="64" y="356">Charlie</text>
                 <text x="128" y="356">Initial</text>
@@ -389,56 +387,53 @@ group consisting of Alice, Bob, and Charlie, with Alice
                 <text x="16" y="388">Add</text>
                 <text x="64" y="388">Charlie</text>
                 <text x="108" y="388">to</text>
-                <text x="144" y="388">Group</text>
-                <text x="32" y="404">Welcome</text>
-                <text x="104" y="404">(Charlie)</text>
+                <text x="144" y="388">group</text>
+                <text x="68" y="404">Welcome(Charlie)</text>
                 <text x="556" y="404">Step</text>
                 <text x="584" y="404">4</text>
                 <text x="336" y="420">Add</text>
                 <text x="384" y="420">Charlie</text>
                 <text x="428" y="420">to</text>
-                <text x="464" y="420">Group</text>
+                <text x="464" y="420">group</text>
                 <text x="336" y="436">Add</text>
                 <text x="384" y="436">Charlie</text>
                 <text x="428" y="436">to</text>
-                <text x="464" y="436">Group</text>
-                <text x="376" y="452">Welcome</text>
-                <text x="448" y="452">(Charlie)</text>
+                <text x="464" y="436">group</text>
+                <text x="420" y="452">Welcome(Charlie)</text>
               </g>
             </svg>
           </artwork>
           <artwork type="ascii-art"><![CDATA[
 Alice     Bob       Charlie                     AS        DS
 
-Create account --------------------------------->               |
-<------------------------------------- Credential               |
-          Create account ----------------------->               | Step 1
-          <--------------------------- Credential               |
-                    Create account ------------->               |
-                    <----------------- Credential               |
+Create account --------------------------------->                |
+<------------------------------------- Credential                |
+          Create account ----------------------->                | Step 1
+          <--------------------------- Credential                |
+                    Create account ------------->                |
+                    <----------------- Credential                |
 
-Initial Keying Material ----------------------------------->    |
-          Initial Keying Material ------------------------->    | Step 2
-                    Initial Keying Material --------------->    |
+Initial Keying Material ----------------------------------->     |
+          Initial Keying Material ------------------------->     | Step 2
+                    Initial Keying Material --------------->     |
 
-Get Bob Initial Keying Material --------------------------->    |
-<------------------------------- Bob Initial Keying Material    |
-Add Bob to Group ------------------------------------------>    | Step 3
-Welcome (Bob) --------------------------------------------->    |
-          <-------------------------------- Add Bob to Group    |
-          <----------------------------------- Welcome (Bob)    |
+Get Bob Initial Keying Material --------------------------->     |
+<------------------------------- Bob Initial Keying Material     |
+Add Bob to group ------------------------------------------>     | Step 3
+Welcome(Bob) ---------------------------------------------->     |
+          <-------------------------------- Add Bob to group     |
+          <------------------------------------ Welcome(Bob)     |
 
-Get Charlie Initial Keying Material ----------------------->    |
-<--------------------------- Charlie Initial Keying Material    |
-Add Charlie to Group -------------------------------------->    |
-Welcome (Charlie) ----------------------------------------->    | Step 4
-          <---------------------------- Add Charlie to Group    |
-                     <----------------- Add Charlie to Group    |
-                     <-------------------- Welcome (Charlie)    |
+Get Charlie Initial Keying Material ----------------------->     |
+<--------------------------- Charlie Initial Keying Material     |
+Add Charlie to group -------------------------------------->     |
+Welcome(Charlie) ------------------------------------------>     | Step 4
+          <---------------------------- Add Charlie to group     |
+                     <----------------- Add Charlie to group     |
+                     <--------------------- Welcome(Charlie)     |
 ]]></artwork>
         </artset>
       </figure>
-
       <t>This process proceeds as follows.</t>
       <section anchor="step-1-account-creation">
         <name>Step 1: Account Creation</name>


### PR DESCRIPTION
@bifurcation PTAL. As before, I'll patch up the HTML once you approve the MD.


Here is my response to the RPC's comments:
> [rfced] Please let us know if any changes are needed for the
> following:
> 
> a) The following term was used inconsistently in this document.
> We chose to use the latter form. Please let us know any objections.
> 
> last resort (2 instances) / "last resort" (4 instances)
> (per Normative Reference RFC 9420)


This is fine.


> b) The following terms appear to be used inconsistently in this
> document. Please let us know which form is preferred.
> Would you like us to follow usage in Normative Reference RFC 9420
> ("The Messaging Layer Security (MLS) Protocol")?
> 
> Most of the terms listed below are also used in RFC 9420. We have
> marked them with asterisks ("*").
> 
>     Application message (3 instances) /
>     application message (12 instances)
>     (e.g., "an Application message", "an application message")
>     (RFC 9420 uses "application message".)

application message.

>     authentication service (Abstract) /
>     Authentication Service (16 instances)
>     (RFC 9420 uses "Authentication Service".)

Fixed.


>     commit (>=13 instances) / Commit (>50 instances)
>     (e.g., "the commit", "the Commit", "any commits", "any Commits")
>     (RFC 9420 uses both forms but appears to use lowercase when this
>     term is used generally. Please review usage in this document
>     and advise.)

It looks to me like 9420 uses Commit to refer to messages, which
is what we are doing here.


>     credential type (1 instance) / Credential type (8 instances)
>     (We also see "credential types" in Section 7.)
>     (RFC 9420 uses "credential type".)

Lower case. Fixed.


>     delivery service (2 instances) / Delivery Service (>40 instances)
>     (RFC 9420 uses "Delivery Service".)

Fixed when I changed to DS.


> Eventually Consistent / eventually consistent (1 instance each)
> (We also see "strongly and eventually consistent systems" in
> Section 5.2.)

I think this is fine as-is, as the upper case version is clearly
being used in the sense of aname.


>     forward secrecy (3 instances) / Forward Secrecy (1 instance
>     other than where defined)
>     (RFC 9420 uses "forward secrecy". We changed "forward-secrecy"
>     in this document to "forward secrecy" for now.)

forward secrecy. Fixed.


>     group / Group (used generally)
>     (e.g., "a group", "a Group", "the group", "that group",
>     "that Group")
>     (RFC 9420 uses "a group", "the group", "that group", etc.)
>
> group operation message (7 instances) /
> Group Operation message (2 instances in Section 8.3.1.1)
> 
>     group secret (10 instances) / Group Secret (2 instances) /
>     Group secret (1 instance)
>     (RFC 9420 uses "group secret".)

I lower cased these.


>     Handshake message (2 instances) / handshake message (9 instances)
>     (RFC 9420 uses "handshake message".)

Lower cased. Fixed.


> Key Transparency (2 instances) /
> key transparency (2 instances) (e.g., "Key Transparency [KT]",
> "key transparency mechanism")

This is fine. KT is both a proper name and a generic,
unfortunately.



>     keypair (4 instances) / key pair (5 instances)
>     (RFC 9420 uses "key pair".)

key pair. Fixed.


>     Member (3 instances) / member (>50 instances) (used generally)
>     (e.g., "When a client is part of a Group, it is called a
>     Member", "all Members", "all members")
>     (RFC 9420 uses "member".)

Lower case. Fixed.


>     Plaintext (1 instance) / plaintext (3 instances)
>     ("MLS Plaintext messages", "plaintext and ciphertext messages")
>     (RFC 9420 uses "plaintext" in running text.)

lower case. Fixed.


>     post-compromise security / Post-Compromise Security
>     (RFC 9420 uses "post-compromise security".)

Fixed earlier.


>     proposal (23 instances) / Proposal (5 instances)
>     (used generally, e.g., "the proposal", "the Proposal",
>     "of proposals", "of Proposals")
>     RFC 9420 uses initial capitalization when referring to a
>     Proposal object and lowercase when used generally. We
>     cannot determine general uses versus referring to a
>     Proposal object here. Please review and advise.

I have fixed these.


> push notification (adj.) (5 instances) /
> push-notification (adj.) (1 instance)
> (e.g., "push notification provider", "push notification
> infrastructure", "push-notification system")
> (Usage in post-6000 published RFCs is mixed.)

push notification. Fixed.

> push tokens (1 instance) / push-tokens (3 instances)
> (No precedent in published RFCs.)

push token. Fixed.


>     ratchet secret (1 instance) / Ratchet Secret (11 instances)
>     (RFC 9420 uses "ratchet secret".)

lower case. Fixed.


> ReInit proposal (3 instances in Section 5.2.3) /
> reinitialization proposal (2 instances in Section 7)

I think this is fine as-is, given the context.



> Service Provider (2 instances) / service provider (10 instances)

Lower case. Fixed.


> Strongly Consistent (2 instances) / strongly consistent (1 instance)

I switched one to lowercase.


>     x509 / X.509 ("x509 Credential type", "X.509 certificates")
>     (RFC 9420 uses "X509Credential" and "X.509 credential".)

This is correct. The use of bare `x509` refers to the `x509` value
in the CredentialType.


> c) In the XML file, we see that emphasis ("") for
> "Welcome message" is applied three times, while all other instances
> of "" are used only once for a given word or term (where the term
> is first used). Is "Welcome message" a special case, or should the
> second and third instances of "" be removed for this term?

The XML was just generated from the .md. I've repaired
the markdown.


> d) Would you like spacing to be consistent?
> 
> Welcome (Bob) / Add(Bob)
> (RFC 9420 does not use spacing between "Welcome" or "Add" and the
> parenthetical item that follows those terms.)
> 
> Notes re. the SVG:
> In the SVG for Figure 2, we found that a closing parenthesis was
> missing after the first "Bob": (Bob
> We added the closing parenthesis. However, as a result, there
> isn't a space between "(Bob)" and the arrow line.
> 
> If you want to change "Welcome (Bob)" to "Welcome(Bob)" in line with
> RFC 9420, we will need you to modify the entries in the SVG.
> If you want to have a space after the first "Bob" in Figure 2, we
> will need you to make that update as well.

I have repaired the markdown. You should be able to regenerate the
SVG using whatever process you used before.